### PR TITLE
Lower memory usage during text extraction

### DIFF
--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -192,6 +192,14 @@ class TextConverter(PDFConverter):
         self.write_text('\f')
         return
 
+    # Some dummy functions to save memory/CPU when all that is wanted is text.
+    # This stops all the image and drawing ouput from being recorded and taking
+    # up RAM.
+    def render_image(self, name, stream):
+        pass
+    def paint_path(self, gstate, stroke, fill, evenodd, path):
+        pass
+
 
 ##  HTMLConverter
 ##


### PR DESCRIPTION
A tiny patch that lowers memory usage when extracting text from pdfs with lots of images. It does this by adding 2 dummy functions to TextConverter so that all the drawing commands are immediately discarded as the PDF is processed.

For my test PDF it went from 320Mb peak during processing to ~50Mb peak.

pdfminer pass all tests.
