### PR TITLE
fix crash in syntax error

### DIFF
--- a/pdfminer/pdfparser.py
+++ b/pdfminer/pdfparser.py
@@ -454,7 +454,10 @@ class PDFDocument(object):
                 try:
                     obj = objs[i]
                 except IndexError:
-                    raise PDFSyntaxError('Invalid object number: objid=%r' % (objid))
+                    if STRICT:
+                        raise PDFSyntaxError('Invalid object number: objid=%r' % (objid))
+                    # return None for an invalid object number
+                    return None
                 if isinstance(obj, PDFStream):
                     obj.set_objid(objid, 0)
             else:


### PR DESCRIPTION
when an object id is out of range, rather than crashing, only raise a
pdf syntax error if STRICT is enabled and return None otherwise
