### PR TITLE
PDFDocument.lookup_name.lookup isn't searching for 'Names' key.

### DIFF
--- a/pdfminer/pdfparser.py
+++ b/pdfminer/pdfparser.py
@@ -553,10 +553,10 @@ class PDFDocument(object):
             if 'Limits' in d:
                 (k1,k2) = list_value(d['Limits'])
                 if key < k1 or k2 < key: return None
-                if 'Names' in d:
-                    objs = list_value(d['Names'])
-                    names = dict(choplist(2, objs))
-                    return names[key]
+            if 'Names' in d:
+                objs = list_value(d['Names'])
+                names = dict(choplist(2, objs))
+                return names[key]
             if 'Kids' in d:
                 for c in list_value(d['Kids']):
                     v = lookup(dict_value(c))


### PR DESCRIPTION
Hi,

```
I don't know pdf format very well, so, I'll try to explain what happened and how i fixed this bug.
```

Couple of months ago, I sended a patch to search for keys when destinations are strings. Now, I found a bug with this case. One pdf file created with Acrobat InDesign CS 5 was making PDFDocument.get_dest throw a PDFDestinationNotFound for all names.

This happened because PDFDocument.lookup_name.lookup wasn't testing for 'Names'. Reading the code, looks like a indent error, where the if searching for 'Names' didn't should be inside the if searching for 'Limits'.  
