### PR TITLE
2x faster layout analysis: Use set instead of list for Plane's internal collection of objects.

### DIFF
--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -246,7 +246,7 @@ class ObjIdRange(object):
 class Plane(object):
 
     def __init__(self, objs=None, gridsize=50):
-        self._objs = []
+        self._objs = set()
         self._grid = {}
         self.gridsize = gridsize
         if objs is not None:
@@ -281,7 +281,7 @@ class Plane(object):
             else:
                 r = self._grid[k]
             r.append(obj)
-        self._objs.append(obj)
+        self._objs.add(obj)
         return
 
     # remove(obj): displace an object.


### PR DESCRIPTION
This patch changes utils.Plane._objs from a [] to a set(). In my tests, this results in layout analysis (PDFPageInterpreter.process_page) running more than twice as fast, and has no effect on the generated etree.

The reason this helps so much is that LTLayoutContainer.group_textboxes() runs Plane.**contains**() in a tight loop. For an ordinary PDF I tried, it ran over 5 million times per page. "obj in set()" turns out to be way faster than "obj in []"

Note: since the generated etrees are identical, I _assume_  there's no reason for Plane._objs to be ordered, and I don't see any reason in the rest of Plane's code. But I'm not familiar with the whole code base, so check me on that.

Thanks!
Jack
