### PR TITLE
2x faster group_textboxes function.

### DIFF
--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -609,8 +609,8 @@ class LTLayoutContainer(LTContainer):
                 group = LTTextGroupLRTB([obj1,obj2])
             plane.remove(obj1)
             plane.remove(obj2)
-            dists = [ (c,d,o1,o2) for (c,d,o1,o2) in dists
-                      if o1 in plane and o2 in plane ]
+            # this line is optimized -- don't change without profiling
+            dists = [ n for n in dists if n[2] in plane._objs and n[3] in plane._objs ]
             for other in plane:
                 dists.append((0, dist(group,other), group, other))
             dists.sort()


### PR DESCRIPTION
This patch optimizes the line that (after my other pull request) was taking the most time when getting a layout. It changes two things:
- Using "n for n in dists" instead of "(c,d,obj1,obj2) for (c,d,obj1,obj2) in dists" avoids a lot of copying.
- Using "in plane._objs" instead of "plane" is ugly, but avoids a weirdly slow layer of indirection.

I tried a bunch of other optimizations for this line -- filter(), "for" loop and temp variable, set(n[2],n[3]) <= plane, etc. -- and this was the fastest, but someone else might be able to find something better. The result is really good, though. On my system, analyzing a complex page went from 10 seconds to 5 seconds total.

(Note: the time to analyze that page was 25 seconds before applying my other patch. So if you apply both patches, get_layout should go roughly five times as fast as it did before. I'm curious whether other people get the same results.)
