### PR TITLE
handle encrypted (but not password protected) PDFs

### DIFF
--- a/pdfminer/pdfpage.py
+++ b/pdfminer/pdfpage.py
@@ -120,7 +120,11 @@ class PDFPage(object):
         doc = PDFDocument(parser, password=password, caching=caching)
         # Check if the document allows text extraction. If not, abort.
         if check_extractable and not doc.is_extractable:
-            raise PDFTextExtractionNotAllowed('Text extraction is not allowed: %r' % fp)
+            msg = 'Text extraction is not allowed on file %r.\n' % fp
+            msg += 'Document may be encrypted or have DRM protection.\n'
+            msg += 'Either provide a password or consider decrypting with\n'
+            msg += 'a tool like qpdf http://sergey.marechek.com/blog/2012/04/29/184/\n'
+            raise PDFTextExtractionNotAllowed(msg)
         # Process each page contained in the document.
         for (pageno, page) in enumerate(klass.create_pages(doc)):
             if pagenos and (pageno not in pagenos):


### PR DESCRIPTION
For example, [this document](http://www.chcf.org/~/media/MEDIA%20LIBRARY%20Files/PDF/P/PDF%20PatientSelfMgt.pdf) is encrypted but not password protected. This is the output I get when trying to convert to html:

``` bash
[unix]$ pdf2txt.py -t html -o kk.html encrypted.pdf
Traceback (most recent call last):
  File "/usr/local/bin/pdf2txt.py", line 115, in <module>
    if __name__ == '__main__': sys.exit(main(sys.argv))
  File "/usr/local/bin/pdf2txt.py", line 107, in main
    caching=caching, check_extractable=True):
  File "/usr/local/lib/python2.7/dist-packages/pdfminer/pdfpage.py", line 124, in get_pages
    raise PDFTextExtractionNotAllowed('Text extraction is not allowed: %r' % fp)
pdfminer.pdfdocument.PDFTextExtractionNotAllowed: Text extraction is not allowed: <open file 'key_findings/california_healthcare_foundation_9231.pdf', mode 'rb' at 0xb6f06d30>
```

Could probably [use qpdf to decrypt](http://sergey.marechek.com/blog/2012/04/29/184/) the output as necessary.
