### PR TITLE
Removed 341 unnecessary empty 'return' statements

### DIFF
--- a/pdfminer/arcfour.py
+++ b/pdfminer/arcfour.py
@@ -29,7 +29,6 @@ class Arcfour(object):
             (s[i], s[j]) = (s[j], s[i])
         self.s = s
         (self.i, self.j) = (0, 0)
-        return
 
     def process(self, data):
         (i, j) = (self.i, self.j)
@@ -43,7 +42,7 @@ class Arcfour(object):
             r += chr(ord(c) ^ k)
         (self.i, self.j) = (i, j)
         return r
-    
+
     encrypt = decrypt = process
 
 new = Arcfour

--- a/pdfminer/ccitt.py
+++ b/pdfminer/ccitt.py
@@ -20,7 +20,6 @@ class BitParser(object):
 
     def __init__(self):
         self._pos = 0
-        return
 
     @classmethod
     def add(klass, root, v, bits):
@@ -36,14 +35,12 @@ class BitParser(object):
             else:
                 b = 0
         p[b] = v
-        return
 
     def feedbytes(self, data):
         for c in data:
             b = ord(c)
             for m in (128, 64, 32, 16, 8, 4, 2, 1):
                 self._parse_bit(b & m)
-        return
 
     def _parse_bit(self, x):
         if x:
@@ -55,7 +52,6 @@ class BitParser(object):
             self._state = v
         else:
             self._state = self._accept(v)
-        return
 
 
 ##  CCITTG4Parser
@@ -324,7 +320,6 @@ class CCITTG4Parser(BitParser):
         self.width = width
         self.bytealign = bytealign
         self.reset()
-        return
 
     def feedbytes(self, data):
         for c in data:
@@ -337,7 +332,6 @@ class CCITTG4Parser(BitParser):
                 self._state = self.MODE
             except self.EOFB:
                 break
-        return
 
     def _parse_mode(self, mode):
         if mode == 'p':
@@ -422,18 +416,15 @@ class CCITTG4Parser(BitParser):
         self._reset_line()
         self._accept = self._parse_mode
         self._state = self.MODE
-        return
 
     def output_line(self, y, bits):
         print (y, ''.join(str(b) for b in bits))
-        return
 
     def _reset_line(self):
         self._refline = self._curline
         self._curline = array.array('b', [1]*self.width)
         self._curpos = -1
         self._color = 1
-        return
 
     def _flush_line(self):
         if self.width <= self._curpos:
@@ -442,7 +433,6 @@ class CCITTG4Parser(BitParser):
             self._reset_line()
             if self.bytealign:
                 raise self.ByteSkip
-        return
 
     def _do_vertical(self, dx):
         #print '* vertical(%d): curpos=%r, color=%r' % (dx, self._curpos, self._color)
@@ -469,7 +459,6 @@ class CCITTG4Parser(BitParser):
                 self._curline[x] = self._color
         self._curpos = x1
         self._color = 1-self._color
-        return
 
     def _do_pass(self):
         #print '* pass: curpos=%r, color=%r' % (self._curpos, self._color)
@@ -498,7 +487,6 @@ class CCITTG4Parser(BitParser):
         for x in xrange(self._curpos, x1):
             self._curline[x] = self._color
         self._curpos = x1
-        return
 
     def _do_horizontal(self, n1, n2):
         #print '* horizontal(%d,%d): curpos=%r, color=%r' % (n1, n2, self._curpos, self._color)
@@ -516,7 +504,6 @@ class CCITTG4Parser(BitParser):
             self._curline[x] = 1-self._color
             x += 1
         self._curpos = x
-        return
 
     def _do_uncompressed(self, bits):
         #print '* uncompressed(%r): curpos=%r' % (bits, self._curpos)
@@ -524,7 +511,6 @@ class CCITTG4Parser(BitParser):
             self._curline[self._curpos] = int(c)
             self._curpos += 1
             self._flush_line()
-        return
 
 import unittest
 
@@ -543,27 +529,23 @@ class TestCCITTG4Parser(unittest.TestCase):
         parser = self.get_parser('00000')
         parser._do_vertical(0)
         self.assertEqual(parser._curpos, 0)
-        return
 
     def test_b2(self):
         parser = self.get_parser('10000')
         parser._do_vertical(-1)
         self.assertEqual(parser._curpos, 0)
-        return
 
     def test_b3(self):
         parser = self.get_parser('000111')
         parser._do_pass()
         self.assertEqual(parser._curpos, 3)
         self.assertEqual(parser._get_bits(), '111')
-        return
 
     def test_b4(self):
         parser = self.get_parser('00000')
         parser._do_vertical(+2)
         self.assertEqual(parser._curpos, 2)
         self.assertEqual(parser._get_bits(), '11')
-        return
 
     def test_b5(self):
         parser = self.get_parser('11111111100')
@@ -572,7 +554,6 @@ class TestCCITTG4Parser(unittest.TestCase):
         parser._do_vertical(1)
         self.assertEqual(parser._curpos, 10)
         self.assertEqual(parser._get_bits(), '0001111111')
-        return
 
     def test_e1(self):
         parser = self.get_parser('10000')
@@ -581,7 +562,6 @@ class TestCCITTG4Parser(unittest.TestCase):
         parser._do_vertical(0)
         self.assertEqual(parser._curpos, 5)
         self.assertEqual(parser._get_bits(), '10000')
-        return
 
     def test_e2(self):
         parser = self.get_parser('10011')
@@ -590,7 +570,6 @@ class TestCCITTG4Parser(unittest.TestCase):
         parser._do_vertical(2)
         self.assertEqual(parser._curpos, 5)
         self.assertEqual(parser._get_bits(), '10000')
-        return
 
     def test_e3(self):
         parser = self.get_parser('011111')
@@ -604,7 +583,6 @@ class TestCCITTG4Parser(unittest.TestCase):
         parser._do_vertical(0)
         self.assertEqual(parser._curpos, 6)
         self.assertEqual(parser._get_bits(), '011100')
-        return
 
     def test_e4(self):
         parser = self.get_parser('10000')
@@ -615,7 +593,6 @@ class TestCCITTG4Parser(unittest.TestCase):
         parser._do_vertical(0)
         self.assertEqual(parser._curpos, 5)
         self.assertEqual(parser._get_bits(), '10011')
-        return
 
     def test_e5(self):
         parser = self.get_parser('011000')
@@ -625,7 +602,6 @@ class TestCCITTG4Parser(unittest.TestCase):
         parser._do_vertical(3)
         self.assertEqual(parser._curpos, 6)
         self.assertEqual(parser._get_bits(), '011111')
-        return
 
     def test_e6(self):
         parser = self.get_parser('11001')
@@ -634,7 +610,6 @@ class TestCCITTG4Parser(unittest.TestCase):
         parser._do_vertical(0)
         self.assertEqual(parser._curpos, 5)
         self.assertEqual(parser._get_bits(), '11111')
-        return
 
     def test_e7(self):
         parser = self.get_parser('0000000000')
@@ -643,7 +618,6 @@ class TestCCITTG4Parser(unittest.TestCase):
         parser._do_horizontal(2, 6)
         self.assertEqual(parser._curpos, 10)
         self.assertEqual(parser._get_bits(), '1111000000')
-        return
 
     def test_e8(self):
         parser = self.get_parser('001100000')
@@ -654,7 +628,6 @@ class TestCCITTG4Parser(unittest.TestCase):
         parser._do_horizontal(7, 0)
         self.assertEqual(parser._curpos, 9)
         self.assertEqual(parser._get_bits(), '101111111')
-        return
 
     def test_m1(self):
         parser = self.get_parser('10101')
@@ -663,7 +636,6 @@ class TestCCITTG4Parser(unittest.TestCase):
         parser._do_pass()
         self.assertEqual(parser._curpos, 4)
         self.assertEqual(parser._get_bits(), '1111')
-        return
 
     def test_m2(self):
         parser = self.get_parser('101011')
@@ -672,7 +644,6 @@ class TestCCITTG4Parser(unittest.TestCase):
         parser._do_vertical(1)
         parser._do_horizontal(1, 1)
         self.assertEqual(parser._get_bits(), '011101')
-        return
 
     def test_m3(self):
         parser = self.get_parser('10111011')
@@ -681,7 +652,6 @@ class TestCCITTG4Parser(unittest.TestCase):
         parser._do_vertical(1)
         parser._do_vertical(1)
         self.assertEqual(parser._get_bits(), '00000001')
-        return
 
 
 ##  CCITTFaxDecoder
@@ -692,7 +662,6 @@ class CCITTFaxDecoder(CCITTG4Parser):
         CCITTG4Parser.__init__(self, width, bytealign=bytealign)
         self.reversed = reversed
         self._buf = ''
-        return
 
     def close(self):
         return self._buf
@@ -705,7 +674,6 @@ class CCITTFaxDecoder(CCITTG4Parser):
             if b:
                 bytes[i//8] += (128, 64, 32, 16, 8, 4, 2, 1)[i % 8]
         self._buf += bytes.tostring()
-        return
 
 
 def ccittfaxdecode(data, params):
@@ -731,7 +699,6 @@ def main(argv):
             import pygame
             CCITTG4Parser.__init__(self, width, bytealign=bytealign)
             self.img = pygame.Surface((self.width, 1000))
-            return
 
         def output_line(self, y, bits):
             for (x, b) in enumerate(bits):
@@ -739,12 +706,11 @@ def main(argv):
                     self.img.set_at((x, y), (255, 255, 255))
                 else:
                     self.img.set_at((x, y), (0, 0, 0))
-            return
 
         def close(self):
             import pygame
             pygame.image.save(self.img, 'out.bmp')
-            return
+
     for path in argv[1:]:
         fp = file(path, 'rb')
         (_, _, k, w, h, _) = path.split('.')
@@ -752,7 +718,6 @@ def main(argv):
         parser.feedbytes(fp.read())
         parser.close()
         fp.close()
-    return
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))

--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -43,23 +43,21 @@ class CMapBase(object):
 
     def __init__(self, **kwargs):
         self.attrs = kwargs.copy()
-        return
 
     def is_vertical(self):
         return self.attrs.get('WMode', 0) != 0
 
     def set_attr(self, k, v):
         self.attrs[k] = v
-        return
 
     def add_code2cid(self, code, cid):
-        return
+        pass
 
     def add_cid2unichr(self, cid, code):
-        return
+        pass
 
     def use_cmap(self, cmap):
-        return
+        pass
 
 
 ##  CMap
@@ -69,7 +67,6 @@ class CMap(CMapBase):
     def __init__(self, **kwargs):
         CMapBase.__init__(self, **kwargs)
         self.code2cid = {}
-        return
 
     def __repr__(self):
         return '<CMap: %s>' % self.attrs.get('CMapName')
@@ -86,7 +83,6 @@ class CMap(CMapBase):
                 else:
                     dst[k] = v
         copy(self.code2cid, cmap.code2cid)
-        return
 
     def decode(self, code):
         if self.debug:
@@ -101,7 +97,6 @@ class CMap(CMapBase):
                     d = self.code2cid
             else:
                 d = self.code2cid
-        return
 
     def dump(self, out=sys.stdout, code2cid=None, code=None):
         if code2cid is None:
@@ -113,7 +108,6 @@ class CMap(CMapBase):
                 out.write('code %r = cid %d\n' % (c, v))
             else:
                 self.dump(out=out, code2cid=v, code=c)
-        return
 
 
 ##  IdentityCMap
@@ -135,7 +129,6 @@ class UnicodeMap(CMapBase):
     def __init__(self, **kwargs):
         CMapBase.__init__(self, **kwargs)
         self.cid2unichr = {}
-        return
 
     def __repr__(self):
         return '<UnicodeMap: %s>' % self.attrs.get('CMapName')
@@ -148,7 +141,6 @@ class UnicodeMap(CMapBase):
     def dump(self, out=sys.stdout):
         for (k, v) in sorted(self.cid2unichr.iteritems()):
             out.write('cid %d = unicode %r\n' % (k, v))
-        return
 
 
 ##  FileCMap
@@ -168,7 +160,6 @@ class FileCMap(CMap):
                 d = t
         c = ord(code[-1])
         d[c] = cid
-        return
 
 
 ##  FileUnicodeMap
@@ -187,7 +178,6 @@ class FileUnicodeMap(UnicodeMap):
             self.cid2unichr[cid] = unichr(code)
         else:
             raise TypeError(code)
-        return
 
 
 ##  PyCMap
@@ -199,7 +189,6 @@ class PyCMap(CMap):
         self.code2cid = module.CODE2CID
         if module.IS_VERTICAL:
             self.attrs['WMode'] = 1
-        return
 
 
 ##  PyUnicodeMap
@@ -213,7 +202,6 @@ class PyUnicodeMap(UnicodeMap):
             self.attrs['WMode'] = 1
         else:
             self.cid2unichr = module.CID2UNICHR_H
-        return
 
 
 ##  CMapDB
@@ -277,14 +265,12 @@ class CMapParser(PSStackParser):
         self.cmap = cmap
         # some ToUnicode maps don't have "begincmap" keyword.
         self._in_cmap = True
-        return
 
     def run(self):
         try:
             self.nextobject()
         except PSEOF:
             pass
-        return
 
     def do_keyword(self, pos, token):
         name = token.name
@@ -400,7 +386,6 @@ class CMapParser(PSStackParser):
             return
 
         self.push((pos, token))
-        return
 
 
 # test
@@ -413,7 +398,6 @@ def main(argv):
         CMapParser(cmap, fp).run()
         fp.close()
         cmap.dump()
-    return
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -31,7 +31,6 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         self.pageno = pageno
         self.laparams = laparams
         self._stack = []
-        return
 
     def begin_page(self, page, ctm):
         (x0, y0, x1, y1) = page.mediabox
@@ -39,7 +38,6 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         (x1, y1) = apply_matrix_pt(ctm, (x1, y1))
         mediabox = (0, 0, abs(x0-x1), abs(y0-y1))
         self.cur_item = LTPage(self.pageno, mediabox)
-        return
 
     def end_page(self, page):
         assert not self._stack
@@ -48,19 +46,16 @@ class PDFLayoutAnalyzer(PDFTextDevice):
             self.cur_item.analyze(self.laparams)
         self.pageno += 1
         self.receive_layout(self.cur_item)
-        return
 
     def begin_figure(self, name, bbox, matrix):
         self._stack.append(self.cur_item)
         self.cur_item = LTFigure(name, bbox, mult_matrix(matrix, self.ctm))
-        return
 
     def end_figure(self, _):
         fig = self.cur_item
         assert isinstance(self.cur_item, LTFigure)
         self.cur_item = self._stack.pop()
         self.cur_item.add(fig)
-        return
 
     def render_image(self, name, stream):
         assert isinstance(self.cur_item, LTFigure)
@@ -68,7 +63,6 @@ class PDFLayoutAnalyzer(PDFTextDevice):
                        (self.cur_item.x0, self.cur_item.y0,
                         self.cur_item.x1, self.cur_item.y1))
         self.cur_item.add(item)
-        return
 
     def paint_path(self, gstate, stroke, fill, evenodd, path):
         shape = ''.join(x[0] for x in path)
@@ -101,7 +95,6 @@ class PDFLayoutAnalyzer(PDFTextDevice):
             for i in xrange(1, len(p), 2):
                 pts.append(apply_matrix_pt(self.ctm, (p[i], p[i+1])))
         self.cur_item.add(LTCurve(gstate.linewidth, pts))
-        return
 
     def render_char(self, matrix, font, fontsize, scaling, rise, cid):
         try:
@@ -120,7 +113,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         return '(cid:%d)' % cid
 
     def receive_layout(self, ltpage):
-        return
+        pass
 
 
 ##  PDFPageAggregator
@@ -130,11 +123,9 @@ class PDFPageAggregator(PDFLayoutAnalyzer):
     def __init__(self, rsrcmgr, pageno=1, laparams=None):
         PDFLayoutAnalyzer.__init__(self, rsrcmgr, pageno=pageno, laparams=laparams)
         self.result = None
-        return
 
     def receive_layout(self, ltpage):
         self.result = ltpage
-        return
 
     def get_result(self):
         return self.result
@@ -148,7 +139,6 @@ class PDFConverter(PDFLayoutAnalyzer):
         PDFLayoutAnalyzer.__init__(self, rsrcmgr, pageno=pageno, laparams=laparams)
         self.outfp = outfp
         self.codec = codec
-        return
 
 
 ##  TextConverter
@@ -160,11 +150,9 @@ class TextConverter(PDFConverter):
         PDFConverter.__init__(self, rsrcmgr, outfp, codec=codec, pageno=pageno, laparams=laparams)
         self.showpageno = showpageno
         self.imagewriter = imagewriter
-        return
 
     def write_text(self, text):
         self.outfp.write(text.encode(self.codec, 'ignore'))
-        return
 
     def receive_layout(self, ltpage):
         def render(item):
@@ -182,7 +170,6 @@ class TextConverter(PDFConverter):
             self.write_text('Page %s\n' % ltpage.pageid)
         render(ltpage)
         self.write_text('\f')
-        return
 
     # Some dummy functions to save memory/CPU when all that is wanted
     # is text.  This stops all the image and drawing ouput from being
@@ -191,10 +178,9 @@ class TextConverter(PDFConverter):
         if self.imagewriter is None:
             return
         PDFConverter.render_image(self, name, stream)
-        return
 
     def paint_path(self, gstate, stroke, fill, evenodd, path):
-        return
+        pass
 
 
 ##  HTMLConverter
@@ -237,27 +223,22 @@ class HTMLConverter(PDFConverter):
         self._font = None
         self._fontstack = []
         self.write_header()
-        return
 
     def write(self, text):
         self.outfp.write(text)
-        return
 
     def write_header(self):
         self.write('<html><head>\n')
         self.write('<meta http-equiv="Content-Type" content="text/html; charset=%s">\n' % self.codec)
         self.write('</head><body>\n')
-        return
 
     def write_footer(self):
         self.write('<div style="position:absolute; top:0px;">Page: %s</div>\n' %
                    ', '.join('<a href="#%s">%s</a>' % (i, i) for i in xrange(1, self.pageno)))
         self.write('</body></html>\n')
-        return
 
     def write_text(self, text):
         self.write(enc(text, self.codec))
-        return
 
     def place_rect(self, color, borderwidth, x, y, w, h):
         color = self.rect_colors.get(color)
@@ -267,11 +248,9 @@ class HTMLConverter(PDFConverter):
                        (color, borderwidth,
                         x*self.scale, (self._yoffset-y)*self.scale,
                         w*self.scale, h*self.scale))
-        return
 
     def place_border(self, color, borderwidth, item):
         self.place_rect(color, borderwidth, item.x0, item.y1, item.width, item.height)
-        return
 
     def place_image(self, item, borderwidth, x, y, w, h):
         if self.imagewriter is not None:
@@ -281,7 +260,6 @@ class HTMLConverter(PDFConverter):
                        (enc(name), borderwidth,
                         x*self.scale, (self._yoffset-y)*self.scale,
                         w*self.scale, h*self.scale))
-        return
 
     def place_text(self, color, text, x, y, size):
         color = self.text_colors.get(color)
@@ -290,7 +268,6 @@ class HTMLConverter(PDFConverter):
                        (color, x*self.scale, (self._yoffset-y)*self.scale, size*self.scale*self.fontscale))
             self.write_text(text)
             self.write('</span>\n')
-        return
 
     def begin_div(self, color, borderwidth, x, y, w, h, writing_mode=False):
         self._fontstack.append(self._font)
@@ -300,14 +277,12 @@ class HTMLConverter(PDFConverter):
                    (color, borderwidth, writing_mode,
                     x*self.scale, (self._yoffset-y)*self.scale,
                     w*self.scale, h*self.scale))
-        return
 
     def end_div(self, color):
         if self._font is not None:
             self.write('</span>')
         self._font = self._fontstack.pop()
         self.write('</div>')
-        return
 
     def put_text(self, text, fontname, fontsize):
         font = (fontname, fontsize)
@@ -318,11 +293,9 @@ class HTMLConverter(PDFConverter):
                        (fontname, fontsize * self.scale * self.fontscale))
             self._font = font
         self.write_text(text)
-        return
 
     def put_newline(self):
         self.write('<br>')
-        return
 
     def receive_layout(self, ltpage):
         def show_group(item):
@@ -330,7 +303,6 @@ class HTMLConverter(PDFConverter):
                 self.place_border('textgroup', 1, item)
                 for child in item:
                     show_group(child)
-            return
 
         def render(item):
             if isinstance(item, LTPage):
@@ -387,11 +359,9 @@ class HTMLConverter(PDFConverter):
             return
         render(ltpage)
         self._yoffset += self.pagemargin
-        return
 
     def close(self):
         self.write_footer()
-        return
 
 
 ##  XMLConverter
@@ -406,22 +376,18 @@ class XMLConverter(PDFConverter):
         self.imagewriter = imagewriter
         self.stripcontrol = stripcontrol
         self.write_header()
-        return
 
     def write_header(self):
         self.outfp.write('<?xml version="1.0" encoding="%s" ?>\n' % self.codec)
         self.outfp.write('<pages>\n')
-        return
 
     def write_footer(self):
         self.outfp.write('</pages>\n')
-        return
 
     def write_text(self, text):
         if self.stripcontrol:
             text = self.CONTROL.sub(u'', text)
         self.outfp.write(enc(text, self.codec))
-        return
 
     def receive_layout(self, ltpage):
         def show_group(item):
@@ -433,7 +399,6 @@ class XMLConverter(PDFConverter):
                 for child in item:
                     show_group(child)
                 self.outfp.write('</textgroup>\n')
-            return
 
         def render(item):
             if isinstance(item, LTPage):
@@ -495,8 +460,6 @@ class XMLConverter(PDFConverter):
                 assert 0, item
             return
         render(ltpage)
-        return
 
     def close(self):
         self.write_footer()
-        return

--- a/pdfminer/image.py
+++ b/pdfminer/image.py
@@ -49,12 +49,10 @@ class BMPWriter(object):
                 self.fp.write(struct.pack('BBBx', i, i, i))
         self.pos0 = self.fp.tell()
         self.pos1 = self.pos0 + self.datasize
-        return
 
     def write_line(self, y, data):
         self.fp.seek(self.pos1 - (y+1)*self.linesize)
         self.fp.write(data)
-        return
 
 
 ##  ImageWriter
@@ -65,7 +63,6 @@ class ImageWriter(object):
         self.outdir = outdir
         if not os.path.exists(self.outdir):
             os.makedirs(self.outdir)
-        return
 
     def export_image(self, image):
         stream = image.stream

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -16,7 +16,6 @@ class IndexAssigner(object):
 
     def __init__(self, index=0):
         self.index = index
-        return
 
     def run(self, obj):
         if isinstance(obj, LTTextBox):
@@ -25,7 +24,6 @@ class IndexAssigner(object):
         elif isinstance(obj, LTTextGroup):
             for x in obj:
                 self.run(x)
-        return
 
 
 ##  LAParams
@@ -47,7 +45,6 @@ class LAParams(object):
         self.boxes_flow = boxes_flow
         self.detect_vertical = detect_vertical
         self.all_texts = all_texts
-        return
 
     def __repr__(self):
         return ('<LAParams: char_margin=%.1f, line_margin=%.1f, word_margin=%.1f all_texts=%r>' %
@@ -60,7 +57,7 @@ class LTItem(object):
 
     def analyze(self, laparams):
         """Perform the layout analysis."""
-        return
+        pass
 
 
 ##  LTText
@@ -82,7 +79,6 @@ class LTComponent(LTItem):
     def __init__(self, bbox):
         LTItem.__init__(self)
         self.set_bbox(bbox)
-        return
 
     def __repr__(self):
         return ('<%s %s>' %
@@ -107,7 +103,6 @@ class LTComponent(LTItem):
         self.width = x1-x0
         self.height = y1-y0
         self.bbox = bbox
-        return
 
     def is_empty(self):
         return self.width <= 0 or self.height <= 0
@@ -157,7 +152,6 @@ class LTCurve(LTComponent):
         LTComponent.__init__(self, get_bound(pts))
         self.pts = pts
         self.linewidth = linewidth
-        return
 
     def get_pts(self):
         return ','.join('%.3f,%.3f' % p for p in self.pts)
@@ -169,7 +163,6 @@ class LTLine(LTCurve):
 
     def __init__(self, linewidth, p0, p1):
         LTCurve.__init__(self, linewidth, [p0, p1])
-        return
 
 
 ##  LTRect
@@ -179,7 +172,6 @@ class LTRect(LTCurve):
     def __init__(self, linewidth, bbox):
         (x0, y0, x1, y1) = bbox
         LTCurve.__init__(self, linewidth, [(x0, y0), (x1, y0), (x1, y1), (x0, y1)])
-        return
 
 
 ##  LTImage
@@ -197,7 +189,6 @@ class LTImage(LTComponent):
         self.colorspace = stream.get_any(('CS', 'ColorSpace'))
         if not isinstance(self.colorspace, list):
             self.colorspace = [self.colorspace]
-        return
 
     def __repr__(self):
         return ('<%s(%s) %s %r>' %
@@ -211,7 +202,6 @@ class LTAnno(LTItem, LTText):
 
     def __init__(self, text):
         self._text = text
-        return
 
     def get_text(self):
         return self._text
@@ -262,7 +252,6 @@ class LTChar(LTComponent, LTText):
             self.size = self.width
         else:
             self.size = self.height
-        return
 
     def __repr__(self):
         return ('<%s %s matrix=%s font=%r adv=%s text=%r>' %
@@ -285,7 +274,6 @@ class LTContainer(LTComponent):
     def __init__(self, bbox):
         LTComponent.__init__(self, bbox)
         self._objs = []
-        return
 
     def __iter__(self):
         return iter(self._objs)
@@ -295,17 +283,14 @@ class LTContainer(LTComponent):
 
     def add(self, obj):
         self._objs.append(obj)
-        return
 
     def extend(self, objs):
         for obj in objs:
             self.add(obj)
-        return
 
     def analyze(self, laparams):
         for obj in self._objs:
             obj.analyze(laparams)
-        return
 
 
 ##  LTExpandableContainer
@@ -314,13 +299,11 @@ class LTExpandableContainer(LTContainer):
 
     def __init__(self):
         LTContainer.__init__(self, (+INF, +INF, -INF, -INF))
-        return
 
     def add(self, obj):
         LTContainer.add(self, obj)
         self.set_bbox((min(self.x0, obj.x0), min(self.y0, obj.y0),
                        max(self.x1, obj.x1), max(self.y1, obj.y1)))
-        return
 
 
 ##  LTTextContainer
@@ -330,7 +313,6 @@ class LTTextContainer(LTExpandableContainer, LTText):
     def __init__(self):
         LTText.__init__(self)
         LTExpandableContainer.__init__(self)
-        return
 
     def get_text(self):
         return ''.join(obj.get_text() for obj in self if isinstance(obj, LTText))
@@ -343,7 +325,6 @@ class LTTextLine(LTTextContainer):
     def __init__(self, word_margin):
         LTTextContainer.__init__(self)
         self.word_margin = word_margin
-        return
 
     def __repr__(self):
         return ('<%s %s %r>' %
@@ -353,7 +334,6 @@ class LTTextLine(LTTextContainer):
     def analyze(self, laparams):
         LTTextContainer.analyze(self, laparams)
         LTContainer.add(self, LTAnno('\n'))
-        return
 
     def find_neighbors(self, plane, ratio):
         raise NotImplementedError
@@ -364,7 +344,6 @@ class LTTextLineHorizontal(LTTextLine):
     def __init__(self, word_margin):
         LTTextLine.__init__(self, word_margin)
         self._x1 = +INF
-        return
 
     def add(self, obj):
         if isinstance(obj, LTChar) and self.word_margin:
@@ -373,7 +352,6 @@ class LTTextLineHorizontal(LTTextLine):
                 LTContainer.add(self, LTAnno(' '))
         self._x1 = obj.x1
         LTTextLine.add(self, obj)
-        return
 
     def find_neighbors(self, plane, ratio):
         d = ratio*self.height
@@ -390,7 +368,6 @@ class LTTextLineVertical(LTTextLine):
     def __init__(self, word_margin):
         LTTextLine.__init__(self, word_margin)
         self._y0 = -INF
-        return
 
     def add(self, obj):
         if isinstance(obj, LTChar) and self.word_margin:
@@ -399,7 +376,6 @@ class LTTextLineVertical(LTTextLine):
                 LTContainer.add(self, LTAnno(' '))
         self._y0 = obj.y0
         LTTextLine.add(self, obj)
-        return
 
     def find_neighbors(self, plane, ratio):
         d = ratio*self.width
@@ -421,7 +397,6 @@ class LTTextBox(LTTextContainer):
     def __init__(self):
         LTTextContainer.__init__(self)
         self.index = -1
-        return
 
     def __repr__(self):
         return ('<%s(%s) %s %r>' %
@@ -434,7 +409,6 @@ class LTTextBoxHorizontal(LTTextBox):
     def analyze(self, laparams):
         LTTextBox.analyze(self, laparams)
         self._objs = csort(self._objs, key=lambda obj: -obj.y1)
-        return
 
     def get_writing_mode(self):
         return 'lr-tb'
@@ -445,7 +419,6 @@ class LTTextBoxVertical(LTTextBox):
     def analyze(self, laparams):
         LTTextBox.analyze(self, laparams)
         self._objs = csort(self._objs, key=lambda obj: -obj.x1)
-        return
 
     def get_writing_mode(self):
         return 'tb-rl'
@@ -458,7 +431,6 @@ class LTTextGroup(LTTextContainer):
     def __init__(self, objs):
         LTTextContainer.__init__(self)
         self.extend(objs)
-        return
 
 
 class LTTextGroupLRTB(LTTextGroup):
@@ -469,7 +441,6 @@ class LTTextGroupLRTB(LTTextGroup):
         self._objs = csort(self._objs, key=lambda obj:
                            (1-laparams.boxes_flow)*(obj.x0) -
                            (1+laparams.boxes_flow)*(obj.y0+obj.y1))
-        return
 
 
 class LTTextGroupTBRL(LTTextGroup):
@@ -480,7 +451,6 @@ class LTTextGroupTBRL(LTTextGroup):
         self._objs = csort(self._objs, key=lambda obj:
                            -(1+laparams.boxes_flow)*(obj.x0+obj.x1)
                            - (1-laparams.boxes_flow)*(obj.y1))
-        return
 
 
 ##  LTLayoutContainer
@@ -490,7 +460,6 @@ class LTLayoutContainer(LTContainer):
     def __init__(self, bbox):
         LTContainer.__init__(self, bbox)
         self.groups = None
-        return
 
     # group_objects: group text object to textlines.
     def group_objects(self, laparams, objs):
@@ -514,7 +483,7 @@ class LTLayoutContainer(LTContainer):
                            obj0.voverlap(obj1)) and
                           (obj0.hdistance(obj1) <
                            max(obj0.width, obj1.width) * laparams.char_margin))
-                
+
                 # valign: obj0 and obj1 is vertically aligned.
                 #
                 #   +------+
@@ -536,7 +505,7 @@ class LTLayoutContainer(LTContainer):
                            obj0.hoverlap(obj1)) and
                           (obj0.vdistance(obj1) <
                            max(obj0.height, obj1.height) * laparams.char_margin))
-                
+
                 if ((halign and isinstance(line, LTTextLineHorizontal)) or
                     (valign and isinstance(line, LTTextLineVertical))):
                     line.add(obj1)
@@ -562,7 +531,6 @@ class LTLayoutContainer(LTContainer):
             line = LTTextLineHorizontal(laparams.word_margin)
             line.add(obj0)
         yield line
-        return
 
     # group_textlines: group neighboring lines to textboxes.
     def group_textlines(self, laparams, lines):
@@ -593,7 +561,6 @@ class LTLayoutContainer(LTContainer):
             done.add(box)
             if not box.is_empty():
                 yield box
-        return
 
     # group_textboxes: group textboxes hierarchically.
     def group_textboxes(self, laparams, boxes):
@@ -630,7 +597,7 @@ class LTLayoutContainer(LTContainer):
         def key_obj(t):
             (c,d,_,_) = t
             return (c,d)
-        
+
         # XXX this still takes O(n^2)  :(
         dists = []
         for i in xrange(len(boxes)):
@@ -684,7 +651,6 @@ class LTLayoutContainer(LTContainer):
                 assigner.run(group)
             textboxes.sort(key=lambda box: box.index)
         self._objs = textboxes + otherobjs + empties
-        return
 
 
 ##  LTFigure
@@ -698,7 +664,6 @@ class LTFigure(LTLayoutContainer):
         bbox = get_bound(apply_matrix_pt(matrix, (p, q))
                          for (p, q) in ((x, y), (x+w, y), (x, y+h), (x+w, y+h)))
         LTLayoutContainer.__init__(self, bbox)
-        return
 
     def __repr__(self):
         return ('<%s(%s) %s matrix=%s>' %
@@ -709,7 +674,6 @@ class LTFigure(LTLayoutContainer):
         if not laparams.all_texts:
             return
         LTLayoutContainer.analyze(self, laparams)
-        return
 
 
 ##  LTPage
@@ -720,7 +684,6 @@ class LTPage(LTLayoutContainer):
         LTLayoutContainer.__init__(self, bbox)
         self.pageid = pageid
         self.rotate = rotate
-        return
 
     def __repr__(self):
         return ('<%s(%r) %s rotate=%r>' %

--- a/pdfminer/lzw.py
+++ b/pdfminer/lzw.py
@@ -17,7 +17,6 @@ class LZWDecoder(object):
         self.nbits = 9
         self.table = None
         self.prevbuf = None
-        return
 
     def readbits(self, bits):
         v = 0
@@ -89,7 +88,6 @@ class LZWDecoder(object):
             yield x
             #logging.debug('nbits=%d, code=%d, output=%r, table=%r' %
             #              (self.nbits, code, x, self.table[258:]))
-        return
 
 
 # lzwdecode

--- a/pdfminer/pdfcolor.py
+++ b/pdfminer/pdfcolor.py
@@ -14,7 +14,6 @@ class PDFColorSpace(object):
     def __init__(self, name, ncomponents):
         self.name = name
         self.ncomponents = ncomponents
-        return
 
     def __repr__(self):
         return '<PDFColorSpace: %s, ncomponents=%d>' % (self.name, self.ncomponents)

--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -14,47 +14,45 @@ class PDFDevice(object):
     def __init__(self, rsrcmgr):
         self.rsrcmgr = rsrcmgr
         self.ctm = None
-        return
 
     def __repr__(self):
         return '<PDFDevice>'
 
     def close(self):
-        return
+        pass
 
     def set_ctm(self, ctm):
         self.ctm = ctm
-        return
 
     def begin_tag(self, tag, props=None):
-        return
+        pass
 
     def end_tag(self):
-        return
+        pass
 
     def do_tag(self, tag, props=None):
-        return
+        pass
 
     def begin_page(self, page, ctm):
-        return
+        pass
 
     def end_page(self, page):
-        return
+        pass
 
     def begin_figure(self, name, bbox, matrix):
-        return
+        pass
 
     def end_figure(self, name):
-        return
+        pass
 
     def paint_path(self, graphicstate, stroke, fill, evenodd, path):
-        return
+        pass
 
     def render_image(self, name, stream):
-        return
+        pass
 
     def render_string(self, textstate, seq):
-        return
+        pass
 
 
 ##  PDFTextDevice
@@ -80,7 +78,6 @@ class PDFTextDevice(PDFDevice):
             textstate.linematrix = self.render_string_horizontal(
                 seq, matrix, textstate.linematrix, font, fontsize,
                 scaling, charspace, wordspace, rise, dxscale)
-        return
 
     def render_string_horizontal(self, seq, matrix, pos,
                                  font, fontsize, scaling, charspace, wordspace, rise, dxscale):
@@ -134,7 +131,6 @@ class TagExtractor(PDFDevice):
         self.codec = codec
         self.pageno = 0
         self._stack = []
-        return
 
     def render_string(self, textstate, seq):
         font = textstate.font
@@ -150,17 +146,14 @@ class TagExtractor(PDFDevice):
                 except PDFUnicodeNotDefined:
                     pass
         self.outfp.write(enc(text, self.codec))
-        return
 
     def begin_page(self, page, ctm):
         self.outfp.write('<page id="%s" bbox="%s" rotate="%d">' %
                          (self.pageno, bbox2str(page.mediabox), page.rotate))
-        return
 
     def end_page(self, page):
         self.outfp.write('</page>\n')
         self.pageno += 1
-        return
 
     def begin_tag(self, tag, props=None):
         s = ''
@@ -169,15 +162,12 @@ class TagExtractor(PDFDevice):
                         in sorted(props.iteritems()))
         self.outfp.write('<%s%s>' % (enc(tag.name), s))
         self._stack.append(tag)
-        return
 
     def end_tag(self):
         assert self._stack
         tag = self._stack.pop(-1)
         self.outfp.write('</%s>' % enc(tag.name))
-        return
 
     def do_tag(self, tag, props=None):
         self.begin_tag(tag, props)
         self._stack.pop(-1)
-        return

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -85,7 +85,6 @@ class PDFXRef(PDFBaseXRef):
     def __init__(self):
         self.offsets = {}
         self.trailer = {}
-        return
 
     def __repr__(self):
         return '<PDFXRef: offsets=%r>' % (self.offsets.keys())
@@ -124,7 +123,6 @@ class PDFXRef(PDFBaseXRef):
                 self.offsets[objid] = (None, long(pos), int(genno))
         logging.info('xref objects: %r' % self.offsets)
         self.load_trailer(parser)
-        return
 
     KEYWORD_TRAILER = KWD('trailer')
 
@@ -139,7 +137,6 @@ class PDFXRef(PDFBaseXRef):
                 raise PDFNoValidXRef('Unexpected EOF - file corrupted')
             (_, dic) = x[0]
         self.trailer.update(dict_value(dic))
-        return
 
     def get_trailer(self):
         return self.trailer
@@ -205,7 +202,6 @@ class PDFXRefFallback(PDFXRef):
                 for index in xrange(n):
                     objid1 = objs[index*2]
                     self.offsets[objid1] = (objid, index, 0)
-        return
 
 
 ##  PDFXRefStream
@@ -217,7 +213,6 @@ class PDFXRefStream(PDFBaseXRef):
         self.entlen = None
         self.fl1 = self.fl2 = self.fl3 = None
         self.ranges = []
-        return
 
     def __repr__(self):
         return '<PDFXRefStream: ranges=%r>' % (self.ranges)
@@ -241,7 +236,6 @@ class PDFXRefStream(PDFBaseXRef):
         logging.info('xref stream: objid=%s, fields=%d,%d,%d' %
                      (', '.join(map(repr, self.ranges)),
                       self.fl1, self.fl2, self.fl3))
-        return
 
     def get_trailer(self):
         return self.trailer
@@ -254,7 +248,6 @@ class PDFXRefStream(PDFBaseXRef):
                 f1 = nunpack(ent[:self.fl1], 1)
                 if f1 == 1 or f1 == 2:
                     yield start+i
-        return
 
     def get_pos(self, objid):
         index = 0
@@ -564,7 +557,6 @@ class PDFDocument(object):
         if self.catalog.get('Type') is not LITERAL_CATALOG:
             if STRICT:
                 raise PDFSyntaxError('Catalog not found!')
-        return
 
     # _initialize_password(password='')
     #   Perform the initialization with a given password.
@@ -582,7 +574,6 @@ class PDFDocument(object):
         self.is_modifiable = handler.is_modifiable()
         self.is_extractable = handler.is_extractable()
         self._parser.fallback = False # need to read streams with exact length
-        return
 
     def _getobj_objstm(self, stream, index, objid):
         if stream.objid in self._parsed_objs:
@@ -689,7 +680,6 @@ class PDFDocument(object):
             if 'Next' in entry:
                 for x in search(entry['Next'], level):
                     yield x
-            return
         return search(self.catalog['Outlines'], 0)
 
     def lookup_name(self, cat, key):
@@ -780,4 +770,3 @@ class PDFDocument(object):
             # find previous xref
             pos = int_value(trailer['Prev'])
             self.read_xref_from(parser, pos, xrefs)
-        return

--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -101,7 +101,6 @@ class Type1FontHeaderParser(PSStackParser):
     def __init__(self, data):
         PSStackParser.__init__(self, data)
         self._cid2unicode = {}
-        return
 
     def get_encoding(self):
         while 1:
@@ -121,7 +120,6 @@ class Type1FontHeaderParser(PSStackParser):
             if (isinstance(key, int) and
                 isinstance(value, PSLiteral)):
                 self.add_results((key, literal_name(value)))
-        return
 
 
 NIBBLES = ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', 'e', 'e-', None, '-')
@@ -268,7 +266,6 @@ class CFFFont(object):
                 self.offsets.append(nunpack(self.fp.read(offsize)))
             self.base = self.fp.tell()-1
             self.fp.seek(self.base+self.offsets[-1])
-            return
 
         def __repr__(self):
             return '<INDEX: size=%d>' % len(self)
@@ -361,7 +358,6 @@ class CFFFont(object):
         #print self.code2gid
         #print self.name2gid
         #assert 0
-        return
 
     def getstr(self, sid):
         if sid < len(self.STANDARD_STRINGS):
@@ -385,7 +381,6 @@ class TrueTypeFont(object):
         for _ in xrange(ntables):
             (name, tsum, offset, length) = struct.unpack('>4sLLL', fp.read(16))
             self.tables[name] = (offset, length)
-        return
 
     def create_unicode_map(self):
         if 'cmap' not in self.tables:
@@ -480,7 +475,6 @@ class PDFFont(object):
         self.leading = num_value(descriptor.get('Leading', 0))
         self.bbox = list_value(descriptor.get('FontBBox', (0, 0, 0, 0)))
         self.hscale = self.vscale = .001
-        return
 
     def __repr__(self):
         return '<PDFFont>'
@@ -551,7 +545,6 @@ class PDFSimpleFont(PDFFont):
             self.unicode_map = FileUnicodeMap()
             CMapParser(self.unicode_map, BytesIO(strm.get_data())).run()
         PDFFont.__init__(self, descriptor, widths)
-        return
 
     def to_unichr(self, cid):
         if self.unicode_map:
@@ -591,7 +584,6 @@ class PDFType1Font(PDFSimpleFont):
             data = self.fontfile.get_data()[:length1]
             parser = Type1FontHeaderParser(BytesIO(data))
             self.cid2unicode = parser.get_encoding()
-        return
 
     def __repr__(self):
         return '<PDFType1Font: basefont=%r>' % self.basefont
@@ -621,7 +613,6 @@ class PDFType3Font(PDFSimpleFont):
         self.matrix = tuple(list_value(spec.get('FontMatrix')))
         (_, self.descent, _, self.ascent) = self.bbox
         (self.hscale, self.vscale) = apply_matrix_norm(self.matrix, (1, 1))
-        return
 
     def __repr__(self):
         return '<PDFType3Font>'
@@ -696,7 +687,6 @@ class PDFCIDFont(PDFFont):
             widths = get_widths(list_value(spec.get('W', [])))
             default_width = spec.get('DW', 1000)
         PDFFont.__init__(self, descriptor, widths, default_width=default_width)
-        return
 
     def __repr__(self):
         return '<PDFCIDFont: basefont=%r, cidcoding=%r>' % (self.basefont, self.cidcoding)
@@ -731,7 +721,6 @@ def main(argv):
         font = CFFFont(fname, fp)
         print (font)
         fp.close()
-    return
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -66,7 +66,6 @@ class PDFTextState(object):
         self.reset()
         # self.matrix is set
         # self.linematrix is set
-        return
 
     def __repr__(self):
         return ('<PDFTextState: font=%r, fontsize=%r, charspace=%r, wordspace=%r, '
@@ -93,7 +92,6 @@ class PDFTextState(object):
     def reset(self):
         self.matrix = MATRIX_IDENTITY
         self.linematrix = (0, 0)
-        return
 
 
 ##  PDFGraphicState
@@ -108,7 +106,6 @@ class PDFGraphicState(object):
         self.dash = None
         self.intent = None
         self.flatness = None
-        return
 
     def copy(self):
         obj = PDFGraphicState()
@@ -142,7 +139,6 @@ class PDFResourceManager(object):
     def __init__(self, caching=True):
         self.caching = caching
         self._cached_fonts = {}
-        return
 
     def get_procset(self, procs):
         for proc in procs:
@@ -153,7 +149,6 @@ class PDFResourceManager(object):
             else:
                 #raise PDFResourceError('ProcSet %r is not supported.' % proc)
                 pass
-        return
 
     def get_cmap(self, cmapname, strict=False):
         try:
@@ -216,7 +211,6 @@ class PDFContentParser(PSStackParser):
         self.streams = streams
         self.istream = 0
         PSStackParser.__init__(self, None)
-        return
 
     def fillfp(self):
         if not self.fp:
@@ -226,12 +220,10 @@ class PDFContentParser(PSStackParser):
             else:
                 raise PSEOF('Unexpected EOF, file truncated?')
             self.fp = BytesIO(strm.get_data())
-        return
 
     def seek(self, pos):
         self.fillfp()
         PSStackParser.seek(self, pos)
-        return
 
     def fillbuf(self):
         if self.charpos < len(self.buf):
@@ -244,7 +236,6 @@ class PDFContentParser(PSStackParser):
                 break
             self.fp = None
         self.charpos = 0
-        return
 
     def get_inline_data(self, pos, target='EI'):
         self.seek(pos)
@@ -278,7 +269,6 @@ class PDFContentParser(PSStackParser):
 
     def flush(self):
         self.add_results(*self.popall())
-        return
 
     KEYWORD_BI = KWD('BI')
     KEYWORD_ID = KWD('ID')
@@ -303,7 +293,6 @@ class PDFContentParser(PSStackParser):
                     raise
         else:
             self.push((pos, token))
-        return
 
 
 ##  Interpreter
@@ -315,7 +304,6 @@ class PDFPageInterpreter(object):
     def __init__(self, rsrcmgr, device):
         self.rsrcmgr = rsrcmgr
         self.device = device
-        return
 
     def dup(self):
         return self.__class__(self.rsrcmgr, self.device)
@@ -359,7 +347,6 @@ class PDFPageInterpreter(object):
             elif k == 'XObject':
                 for (xobjid, xobjstrm) in dict_value(v).iteritems():
                     self.xobjmap[xobjid] = xobjstrm
-        return
 
     # init_state(ctm)
     #   Initialize the text and graphic states for rendering a page.
@@ -377,11 +364,9 @@ class PDFPageInterpreter(object):
         self.scs = self.ncs = None
         if self.csmap:
             self.scs = self.ncs = self.csmap.values()[0]
-        return
 
     def push(self, obj):
         self.argstack.append(obj)
-        return
 
     def pop(self, n):
         if n == 0:
@@ -396,94 +381,77 @@ class PDFPageInterpreter(object):
     def set_current_state(self, state):
         (self.ctm, self.textstate, self.graphicstate) = state
         self.device.set_ctm(self.ctm)
-        return
 
     # gsave
     def do_q(self):
         self.gstack.append(self.get_current_state())
-        return
 
     # grestore
     def do_Q(self):
         if self.gstack:
             self.set_current_state(self.gstack.pop())
-        return
 
     # concat-matrix
     def do_cm(self, a1, b1, c1, d1, e1, f1):
         self.ctm = mult_matrix((a1, b1, c1, d1, e1, f1), self.ctm)
         self.device.set_ctm(self.ctm)
-        return
 
     # setlinewidth
     def do_w(self, linewidth):
         self.graphicstate.linewidth = linewidth
-        return
 
     # setlinecap
     def do_J(self, linecap):
         self.graphicstate.linecap = linecap
-        return
 
     # setlinejoin
     def do_j(self, linejoin):
         self.graphicstate.linejoin = linejoin
-        return
 
     # setmiterlimit
     def do_M(self, miterlimit):
         self.graphicstate.miterlimit = miterlimit
-        return
 
     # setdash
     def do_d(self, dash, phase):
         self.graphicstate.dash = (dash, phase)
-        return
 
     # setintent
     def do_ri(self, intent):
         self.graphicstate.intent = intent
-        return
 
     # setflatness
     def do_i(self, flatness):
         self.graphicstate.flatness = flatness
-        return
 
     # load-gstate
     def do_gs(self, name):
         #XXX
-        return
+        pass
 
     # moveto
     def do_m(self, x, y):
         self.curpath.append(('m', x, y))
-        return
 
     # lineto
     def do_l(self, x, y):
         self.curpath.append(('l', x, y))
-        return
 
     # curveto
     def do_c(self, x1, y1, x2, y2, x3, y3):
         self.curpath.append(('c', x1, y1, x2, y2, x3, y3))
-        return
 
     # urveto
     def do_v(self, x2, y2, x3, y3):
         self.curpath.append(('v', x2, y2, x3, y3))
-        return
 
     # rveto
     def do_y(self, x1, y1, x3, y3):
         self.curpath.append(('y', x1, y1, x3, y3))
-        return
 
     # closepath
     def do_h(self):
         self.curpath.append(('h',))
-        return
 
     # rectangle
     def do_re(self, x, y, w, h):
@@ -492,25 +460,21 @@ class PDFPageInterpreter(object):
         self.curpath.append(('l', x+w, y+h))
         self.curpath.append(('l', x, y+h))
         self.curpath.append(('h',))
-        return
 
     # stroke
     def do_S(self):
         self.device.paint_path(self.graphicstate, True, False, False, self.curpath)
         self.curpath = []
-        return
 
     # close-and-stroke
     def do_s(self):
         self.do_h()
         self.do_S()
-        return
 
     # fill
     def do_f(self):
         self.device.paint_path(self.graphicstate, False, True, False, self.curpath)
         self.curpath = []
-        return
     # fill (obsolete)
     do_F = do_f
 
@@ -518,44 +482,38 @@ class PDFPageInterpreter(object):
     def do_f_a(self):
         self.device.paint_path(self.graphicstate, False, True, True, self.curpath)
         self.curpath = []
-        return
 
     # fill-and-stroke
     def do_B(self):
         self.device.paint_path(self.graphicstate, True, True, False, self.curpath)
         self.curpath = []
-        return
 
     # fill-and-stroke-even-odd
     def do_B_a(self):
         self.device.paint_path(self.graphicstate, True, True, True, self.curpath)
         self.curpath = []
-        return
 
     # close-fill-and-stroke
     def do_b(self):
         self.do_h()
         self.do_B()
-        return
 
     # close-fill-and-stroke-even-odd
     def do_b_a(self):
         self.do_h()
         self.do_B_a()
-        return
 
     # close-only
     def do_n(self):
         self.curpath = []
-        return
 
     # clip
     def do_W(self):
-        return
+        pass
 
     # clip-even-odd
     def do_W_a(self):
-        return
+        pass
 
     # setcolorspace-stroking
     def do_CS(self, name):
@@ -564,7 +522,6 @@ class PDFPageInterpreter(object):
         except KeyError:
             if STRICT:
                 raise PDFInterpreterError('Undefined ColorSpace: %r' % name)
-        return
 
     # setcolorspace-non-strokine
     def do_cs(self, name):
@@ -573,37 +530,36 @@ class PDFPageInterpreter(object):
         except KeyError:
             if STRICT:
                 raise PDFInterpreterError('Undefined ColorSpace: %r' % name)
-        return
 
     # setgray-stroking
     def do_G(self, gray):
         #self.do_CS(LITERAL_DEVICE_GRAY)
-        return
+        pass
 
     # setgray-non-stroking
     def do_g(self, gray):
         #self.do_cs(LITERAL_DEVICE_GRAY)
-        return
+        pass
 
     # setrgb-stroking
     def do_RG(self, r, g, b):
         #self.do_CS(LITERAL_DEVICE_RGB)
-        return
+        pass
 
     # setrgb-non-stroking
     def do_rg(self, r, g, b):
         #self.do_cs(LITERAL_DEVICE_RGB)
-        return
+        pass
 
     # setcmyk-stroking
     def do_K(self, c, m, y, k):
         #self.do_CS(LITERAL_DEVICE_CMYK)
-        return
+        pass
 
     # setcmyk-non-stroking
     def do_k(self, c, m, y, k):
         #self.do_cs(LITERAL_DEVICE_CMYK)
-        return
+        pass
 
     # setcolor
     def do_SCN(self):
@@ -614,7 +570,6 @@ class PDFPageInterpreter(object):
                 raise PDFInterpreterError('No colorspace specified!')
             n = 1
         self.pop(n)
-        return
 
     def do_scn(self):
         if self.ncs:
@@ -624,77 +579,64 @@ class PDFPageInterpreter(object):
                 raise PDFInterpreterError('No colorspace specified!')
             n = 1
         self.pop(n)
-        return
 
     def do_SC(self):
         self.do_SCN()
-        return
 
     def do_sc(self):
         self.do_scn()
-        return
 
     # sharing-name
     def do_sh(self, name):
-        return
+        pass
 
     # begin-text
     def do_BT(self):
         self.textstate.reset()
-        return
 
     # end-text
     def do_ET(self):
-        return
+        pass
 
     # begin-compat
     def do_BX(self):
-        return
+        pass
 
     # end-compat
     def do_EX(self):
-        return
+        pass
 
     # marked content operators
     def do_MP(self, tag):
         self.device.do_tag(tag)
-        return
 
     def do_DP(self, tag, props):
         self.device.do_tag(tag, props)
-        return
 
     def do_BMC(self, tag):
         self.device.begin_tag(tag)
-        return
 
     def do_BDC(self, tag, props):
         self.device.begin_tag(tag, props)
-        return
 
     def do_EMC(self):
         self.device.end_tag()
-        return
 
     # setcharspace
     def do_Tc(self, space):
         self.textstate.charspace = space
-        return
 
     # setwordspace
     def do_Tw(self, space):
         self.textstate.wordspace = space
-        return
 
     # textscale
     def do_Tz(self, scale):
         self.textstate.scaling = scale
-        return
 
     # setleading
     def do_TL(self, leading):
         self.textstate.leading = -leading
-        return
 
     # selectfont
     def do_Tf(self, fontid, fontsize):
@@ -705,17 +647,14 @@ class PDFPageInterpreter(object):
                 raise PDFInterpreterError('Undefined Font id: %r' % fontid)
             self.textstate.font = self.rsrcmgr.get_font(None, {})
         self.textstate.fontsize = fontsize
-        return
 
     # setrendering
     def do_Tr(self, render):
         self.textstate.render = render
-        return
 
     # settextrise
     def do_Ts(self, rise):
         self.textstate.rise = rise
-        return
 
     # text-move
     def do_Td(self, tx, ty):
@@ -723,7 +662,6 @@ class PDFPageInterpreter(object):
         self.textstate.matrix = (a, b, c, d, tx*a+ty*c+e, tx*b+ty*d+f)
         self.textstate.linematrix = (0, 0)
         #print >>sys.stderr, 'Td(%r,%r): %r' % (tx, ty, self.textstate)
-        return
 
     # text-move
     def do_TD(self, tx, ty):
@@ -732,20 +670,17 @@ class PDFPageInterpreter(object):
         self.textstate.leading = ty
         self.textstate.linematrix = (0, 0)
         #print >>sys.stderr, 'TD(%r,%r): %r' % (tx, ty, self.textstate)
-        return
 
     # textmatrix
     def do_Tm(self, a, b, c, d, e, f):
         self.textstate.matrix = (a, b, c, d, e, f)
         self.textstate.linematrix = (0, 0)
-        return
 
     # nextline
     def do_T_a(self):
         (a, b, c, d, e, f) = self.textstate.matrix
         self.textstate.matrix = (a, b, c, d, self.textstate.leading*c+e, self.textstate.leading*d+f)
         self.textstate.linematrix = (0, 0)
-        return
 
     # show-pos
     def do_TJ(self, seq):
@@ -755,32 +690,28 @@ class PDFPageInterpreter(object):
                 raise PDFInterpreterError('No font specified!')
             return
         self.device.render_string(self.textstate, seq)
-        return
 
     # show
     def do_Tj(self, s):
         self.do_TJ([s])
-        return
 
     # quote
     def do__q(self, s):
         self.do_T_a()
         self.do_TJ([s])
-        return
 
     # doublequote
     def do__w(self, aw, ac, s):
         self.do_Tw(aw)
         self.do_Tc(ac)
         self.do_TJ([s])
-        return
 
     # inline image
     def do_BI(self):  # never called
-        return
+        pass
 
     def do_ID(self):  # never called
-        return
+        pass
 
     def do_EI(self, obj):
         if 'W' in obj and 'H' in obj:
@@ -788,7 +719,6 @@ class PDFPageInterpreter(object):
             self.device.begin_figure(iobjid, (0, 0, 1, 1), MATRIX_IDENTITY)
             self.device.render_image(iobjid, obj)
             self.device.end_figure(iobjid)
-        return
 
     # invoke an XObject
     def do_Do(self, xobjid):
@@ -819,7 +749,6 @@ class PDFPageInterpreter(object):
         else:
             # unsupported xobject type.
             pass
-        return
 
     def process_page(self, page):
         logging.info('Processing page: %r' % page)
@@ -835,7 +764,6 @@ class PDFPageInterpreter(object):
         self.device.begin_page(page, ctm)
         self.render_contents(page.resources, page.contents, ctm=ctm)
         self.device.end_page(page)
-        return
 
     # render_contents(resources, streams, ctm)
     #   Render the content streams.
@@ -846,7 +774,6 @@ class PDFPageInterpreter(object):
         self.init_resources(resources)
         self.init_state(ctm)
         self.execute(list_value(streams))
-        return
 
     def execute(self, streams):
         try:
@@ -880,4 +807,3 @@ class PDFPageInterpreter(object):
                         raise PDFInterpreterError('Unknown operator: %r' % name)
             else:
                 self.push(obj)
-        return

--- a/pdfminer/pdfpage.py
+++ b/pdfminer/pdfpage.py
@@ -66,7 +66,6 @@ class PDFPage(object):
         if not isinstance(contents, list):
             contents = [contents]
         self.contents = contents
-        return
 
     def __repr__(self):
         return '<PDFPage: Resources=%r, MediaBox=%r>' % (self.resources, self.mediabox)
@@ -108,7 +107,6 @@ class PDFPage(object):
                             yield klass(document, objid, obj)
                     except PDFObjectNotFound:
                         pass
-        return
 
     @classmethod
     def get_pages(klass, fp,
@@ -128,4 +126,3 @@ class PDFPage(object):
             yield page
             if maxpages and maxpages <= pageno+1:
                 break
-        return

--- a/pdfminer/pdfparser.py
+++ b/pdfminer/pdfparser.py
@@ -43,12 +43,10 @@ class PDFParser(PSStackParser):
         PSStackParser.__init__(self, fp)
         self.doc = None
         self.fallback = False
-        return
 
     def set_document(self, doc):
         """Associates the parser with a PDFDocument object."""
         self.doc = doc
-        return
 
     KEYWORD_R = KWD('R')
     KEYWORD_NULL = KWD('null')
@@ -130,8 +128,6 @@ class PDFParser(PSStackParser):
             # others
             self.push((pos, token))
 
-        return
-
 
 ##  PDFStreamParser
 ##
@@ -147,11 +143,9 @@ class PDFStreamParser(PDFParser):
 
     def __init__(self, data):
         PDFParser.__init__(self, BytesIO(data))
-        return
 
     def flush(self):
         self.add_results(*self.popall())
-        return
 
     KEYWORD_OBJ = KWD('obj')
     def do_keyword(self, pos, token):
@@ -173,4 +167,3 @@ class PDFStreamParser(PDFParser):
             return
         # others
         self.push((pos, token))
-        return

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -57,7 +57,6 @@ class PDFObjRef(PDFObject):
         self.doc = doc
         self.objid = objid
         #self.genno = genno  # Never used.
-        return
 
     def __repr__(self):
         return '<PDFObjRef:%d>' % (self.objid)
@@ -186,12 +185,10 @@ class PDFStream(PDFObject):
         self.data = None
         self.objid = None
         self.genno = None
-        return
 
     def set_objid(self, objid, genno):
         self.objid = objid
         self.genno = genno
-        return
 
     def __repr__(self):
         if self.data is None:
@@ -280,7 +277,6 @@ class PDFStream(PDFObject):
                     raise PDFNotImplementedError('Unsupported predictor: %r' % pred)
         self.data = data
         self.rawdata = None
-        return
 
     def get_data(self):
         if self.data is None:

--- a/pdfminer/psparser.py
+++ b/pdfminer/psparser.py
@@ -57,7 +57,6 @@ class PSLiteral(PSObject):
 
     def __init__(self, name):
         self.name = name
-        return
 
     def __repr__(self):
         return '/%s' % self.name
@@ -79,7 +78,6 @@ class PSKeyword(PSObject):
 
     def __init__(self, name):
         self.name = name
-        return
 
     def __repr__(self):
         return self.name
@@ -97,7 +95,6 @@ class PSSymbolTable(object):
     def __init__(self, klass):
         self.dict = {}
         self.klass = klass
-        return
 
     def intern(self, name):
         if name in self.dict:
@@ -164,17 +161,15 @@ class PSBaseParser(object):
     def __init__(self, fp):
         self.fp = fp
         self.seek(0)
-        return
 
     def __repr__(self):
         return '<%s: %r, bufpos=%d>' % (self.__class__.__name__, self.fp, self.bufpos)
 
     def flush(self):
-        return
+        pass
 
     def close(self):
         self.flush()
-        return
 
     def tell(self):
         return self.bufpos+self.charpos
@@ -186,7 +181,6 @@ class PSBaseParser(object):
         self.fp.seek(pos)
         logging.info('poll(%d): %r' % (pos, self.fp.read(n)))
         self.fp.seek(pos0)
-        return
 
     def seek(self, pos):
         """Seeks the parser to the given position.
@@ -203,7 +197,6 @@ class PSBaseParser(object):
         self._curtoken = ''
         self._curtokenpos = 0
         self._tokens = []
-        return
 
     def fillbuf(self):
         if self.charpos < len(self.buf):
@@ -214,7 +207,6 @@ class PSBaseParser(object):
         if not self.buf:
             raise PSEOF('Unexpected EOF')
         self.charpos = 0
-        return
 
     def nextline(self):
         """Fetches a next line that ends either with \\r or \\n.
@@ -269,7 +261,6 @@ class PSBaseParser(object):
                 yield s[n:]+buf
                 s = s[:n]
                 buf = ''
-        return
 
     def _parse_main(self, s, i):
         m = NONSPC.search(s, i)
@@ -317,7 +308,6 @@ class PSBaseParser(object):
 
     def _add_token(self, obj):
         self._tokens.append((self._curtokenpos, obj))
-        return
 
     def _parse_comment(self, s, i):
         m = EOL.search(s, i)
@@ -494,23 +484,19 @@ class PSStackParser(PSBaseParser):
     def __init__(self, fp):
         PSBaseParser.__init__(self, fp)
         self.reset()
-        return
 
     def reset(self):
         self.context = []
         self.curtype = None
         self.curstack = []
         self.results = []
-        return
 
     def seek(self, pos):
         PSBaseParser.seek(self, pos)
         self.reset()
-        return
 
     def push(self, *objs):
         self.curstack.extend(objs)
-        return
 
     def pop(self, n):
         objs = self.curstack[-n:]
@@ -526,14 +512,12 @@ class PSStackParser(PSBaseParser):
         if self.debug:
             logging.debug('add_results: %r' % objs)
         self.results.extend(objs)
-        return
 
     def start_type(self, pos, type):
         self.context.append((pos, self.curtype, self.curstack))
         (self.curtype, self.curstack) = (type, [])
         if self.debug:
             logging.debug('start_type: pos=%r, type=%r' % (pos, type))
-        return
 
     def end_type(self, type):
         if self.curtype != type:
@@ -545,7 +529,7 @@ class PSStackParser(PSBaseParser):
         return (pos, objs)
 
     def do_keyword(self, pos, token):
-        return
+        pass
 
     def nextobject(self):
         """Yields a list of objects.
@@ -696,13 +680,11 @@ func/a/b{(c)do*}def
         tokens = self.get_tokens(self.TESTDATA)
         print (tokens)
         self.assertEqual(tokens, self.TOKENS)
-        return
 
     def test_2(self):
         objs = self.get_objects(self.TESTDATA)
         print (objs)
         self.assertEqual(objs, self.OBJS)
-        return
 
 if __name__ == '__main__':
     unittest.main()

--- a/pdfminer/rijndael.py
+++ b/pdfminer/rijndael.py
@@ -1053,7 +1053,6 @@ class RijndaelDecryptor(object):
         (self.rk, self.nrounds) = rijndaelSetupDecrypt(key, keybits)
         assert len(self.rk) == RKLENGTH(keybits)
         assert self.nrounds == NROUNDS(keybits)
-        return
 
     def decrypt(self, ciphertext):
         assert len(ciphertext) == 16
@@ -1075,7 +1074,6 @@ class RijndaelEncryptor(object):
         (self.rk, self.nrounds) = rijndaelSetupEncrypt(key, keybits)
         assert len(self.rk) == RKLENGTH(keybits)
         assert self.nrounds == NROUNDS(keybits)
-        return
 
     def encrypt(self, plaintext):
         assert len(plaintext) == 16

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -100,7 +100,6 @@ def uniq(objs):
             continue
         done.add(obj)
         yield obj
-    return
 
 
 # csort
@@ -162,7 +161,6 @@ def choplist(n, seq):
         if len(r) == n:
             yield tuple(r)
             r = []
-    return
 
 
 # nunpack
@@ -260,7 +258,6 @@ class Plane(object):
         self._grid = {}
         self.gridsize = gridsize
         (self.x0, self.y0, self.x1, self.y1) = bbox
-        return
 
     def __repr__(self):
         return ('<Plane objs=%r>' % list(self))
@@ -285,13 +282,11 @@ class Plane(object):
         for y in drange(y0, y1, self.gridsize):
             for x in drange(x0, x1, self.gridsize):
                 yield (x, y)
-        return
 
     # extend(objs)
     def extend(self, objs):
         for obj in objs:
             self.add(obj)
-        return
 
     # add(obj): place an object.
     def add(self, obj):
@@ -304,7 +299,6 @@ class Plane(object):
             r.append(obj)
         self._seq.append(obj)
         self._objs.add(obj)
-        return
 
     # remove(obj): displace an object.
     def remove(self, obj):
@@ -314,7 +308,6 @@ class Plane(object):
             except (KeyError, ValueError):
                 pass
         self._objs.remove(obj)
-        return
 
     # find(): finds objects that are in a certain area.
     def find(self, bbox):
@@ -331,4 +324,3 @@ class Plane(object):
                     obj.y1 <= y0 or y1 <= obj.y0):
                     continue
                 yield obj
-        return

--- a/tools/conv_cmap.py
+++ b/tools/conv_cmap.py
@@ -16,7 +16,6 @@ class CMapConverter(object):
         self.is_vertical = {}
         self.cid2unichr_h = {} # {cid: unichr}
         self.cid2unichr_v = {} # {cid: unichr}
-        return
 
     def get_encs(self):
         return self.code2cid.keys()
@@ -66,7 +65,6 @@ class CMapConverter(object):
                 b = ord(code[-1])
                 if force or ((b not in dmap) or dmap[b] == cid):
                     dmap[b] = cid
-                return
 
             def add(unimap, enc, code):
                 try:
@@ -80,7 +78,6 @@ class CMapConverter(object):
                     pass
                 except UnicodeError:
                     pass
-                return
 
             def pick(unimap):
                 chars = unimap.items()
@@ -131,15 +128,12 @@ class CMapConverter(object):
             if unimap_v or unimap_h:
                 self.cid2unichr_v[cid] = pick(unimap_v or unimap_h)
 
-        return
-
     def dump_cmap(self, fp, enc):
         data = dict(
             IS_VERTICAL=self.is_vertical.get(enc, False),
             CODE2CID=self.code2cid.get(enc),
         )
         fp.write(pickle.dumps(data))
-        return
 
     def dump_unicodemap(self, fp):
         data = dict(
@@ -147,7 +141,6 @@ class CMapConverter(object):
             CID2UNICHR_V=self.cid2unichr_v,
         )
         fp.write(pickle.dumps(data))
-        return
 
 # main
 def main(argv):
@@ -193,6 +186,5 @@ def main(argv):
     fp = gzip.open(path, 'wb')
     converter.dump_unicodemap(fp)
     fp.close()
-    return
 
 if __name__ == '__main__': sys.exit(main(sys.argv))

--- a/tools/dumppdf.py
+++ b/tools/dumppdf.py
@@ -88,7 +88,6 @@ def dumptrailers(out, doc):
         out.write('<trailer>\n')
         dumpxml(out, xref.trailer)
         out.write('\n</trailer>\n\n')
-    return
 
 # dumpallobjs
 def dumpallobjs(out, doc, codec=None):
@@ -108,7 +107,6 @@ def dumpallobjs(out, doc, codec=None):
                 print >>sys.stderr, 'not found: %r' % e
     dumptrailers(out, doc)
     out.write('</pdf>')
-    return
 
 # dumpoutline
 def dumpoutline(outfp, fname, objids, pagenos, password='',
@@ -155,7 +153,6 @@ def dumpoutline(outfp, fname, objids, pagenos, password='',
         pass
     parser.close()
     fp.close()
-    return
 
 # extractembedded
 LITERAL_FILESPEC = LIT('Filespec')
@@ -181,7 +178,6 @@ def extractembedded(outfp, fname, objids, pagenos, password='',
         out = file(path, 'wb')
         out.write(fileobj.get_data())
         out.close()
-        return
 
     fp = file(fname, 'rb')
     parser = PDFParser(fp)
@@ -191,7 +187,6 @@ def extractembedded(outfp, fname, objids, pagenos, password='',
             obj = doc.getobj(objid)
             if isinstance(obj, dict) and obj.get('Type') is LITERAL_FILESPEC:
                 extract1(obj)
-    return
 
 # dumppdf
 def dumppdf(outfp, fname, objids, pagenos, password='',
@@ -219,7 +214,6 @@ def dumppdf(outfp, fname, objids, pagenos, password='',
     fp.close()
     if codec not in ('raw','binary'):
         outfp.write('\n')
-    return
 
 
 # main
@@ -263,6 +257,5 @@ def main(argv):
     for fname in args:
         proc(outfp, fname, objids, pagenos, password=password,
              dumpall=dumpall, codec=codec, extractdir=extractdir)
-    return
 
 if __name__ == '__main__': sys.exit(main(sys.argv))

--- a/tools/latin2ascii.py
+++ b/tools/latin2ascii.py
@@ -125,6 +125,5 @@ def main(argv):
     for line in fileinput.input(args):
         line = latin2ascii(unicode(line, codec, 'ignore'))
         sys.stdout.write(line.encode('ascii', 'replace'))
-    return
 
 if __name__ == '__main__': sys.exit(main(sys.argv))

--- a/tools/pdf2html.cgi
+++ b/tools/pdf2html.cgi
@@ -74,7 +74,6 @@ def convert(infp, outfp, path, codec='utf-8',
         interpreter.process_page(page)
     fp.close()
     device.close()
-    return
 
 
 ##  WebApp
@@ -99,7 +98,6 @@ class WebApp(object):
         self.tmpdir = self.environ.get('TEMP', './var/')
         self.content_type = 'text/html; charset=%s' % codec
         self.logger = logging.getLogger()
-        return
 
     def put(self, *args):
         for x in args:
@@ -107,7 +105,6 @@ class WebApp(object):
                 self.outfp.write(x)
             elif isinstance(x, unicode):
                 self.outfp.write(x.encode(self.codec, 'xmlcharrefreplace'))
-        return
 
     def response_200(self):
         if self.server.startswith('cgi-httpd'):
@@ -115,7 +112,6 @@ class WebApp(object):
             self.outfp.write('HTTP/1.0 200 OK\r\n')
         self.outfp.write('Content-type: %s\r\n' % self.content_type)
         self.outfp.write('Connection: close\r\n\r\n')
-        return
 
     def response_404(self):
         if self.server.startswith('cgi-httpd'):
@@ -124,14 +120,12 @@ class WebApp(object):
         self.outfp.write('Content-type: text/html\r\n')
         self.outfp.write('Connection: close\r\n\r\n')
         self.outfp.write('<html><body>page does not exist</body></body>\n')
-        return
 
     def response_301(self, url):
         if self.server.startswith('cgi-httpd'):
             # required for cgi-httpd
             self.outfp.write('HTTP/1.0 301 Moved\r\n')
         self.outfp.write('Location: %s\r\n\r\n' % url)
-        return
 
     def coverpage(self):
         self.put(
@@ -150,7 +144,6 @@ class WebApp(object):
           '<p>Powered by <a href="http://www.unixuser.org/~euske/python/pdfminer/">PDFMiner</a>-%s\n' % pdfminer.__version__,
           '</body></html>\n',
           )
-        return
 
     def setup(self):
         self.run = self.response_404
@@ -204,7 +197,6 @@ class WebApp(object):
                 os.remove(tmppath)
             except:
                 pass
-        return
 
 
 # main

--- a/tools/pdf2txt.py
+++ b/tools/pdf2txt.py
@@ -111,6 +111,5 @@ def main(argv):
         fp.close()
     device.close()
     outfp.close()
-    return
 
 if __name__ == '__main__': sys.exit(main(sys.argv))

--- a/tools/prof.py
+++ b/tools/prof.py
@@ -24,6 +24,5 @@ def prof_main(argv):
         stats.strip_dirs()
         stats.sort_stats('time', 'calls')
         stats.print_stats(1000)
-    return
 
 if __name__ == '__main__': sys.exit(prof_main(sys.argv))

--- a/tools/runapp.py
+++ b/tools/runapp.py
@@ -82,7 +82,6 @@ class WebAppHandler(SimpleHTTPRequestHandler):
         status = app.setup()
         self.send_response(status, responses[status])
         app.run()
-        return
 
 # main
 def main(argv):
@@ -108,6 +107,5 @@ def main(argv):
     print ('Listening %s:%d...' % (host,port))
     httpd = HTTPServer((host,port), WebAppHandler)
     httpd.serve_forever()
-    return
 
 if __name__ == '__main__': sys.exit(main(sys.argv))


### PR DESCRIPTION
Python doesn't require `return` statements at the end of functions and methods, and I noticed pdfminer had many such unnecessary `return`s. I went through and removed 341 unnecessary statements. Specifically:
- Removed all `return` statements that were the last statement in a function or method.
- For any `return` statements that were the _only_ statement in a function, converted them to a `pass`.

Overall this makes it a simpler, more readable codebase, and it's much more Pythonic.
