### PR TITLE
Allow for center justification in text boxes.

### DIFF
--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -382,7 +382,8 @@ class LTTextLineHorizontal(LTTextLine):
                 if (isinstance(obj, LTTextLineHorizontal) and
                     abs(obj.height-self.height) < d and
                     (abs(obj.x0-self.x0) < d or
-                     abs(obj.x1-self.x1) < d))]
+                     abs(obj.x1-self.x1) < d or
+                     (obj.x0 > self.x0 and obj.x1 < self.x1)))]
 
 
 class LTTextLineVertical(LTTextLine):


### PR DESCRIPTION
Before, two lines of text were neighbors and added to the same LTHorizontalTextBox if the left or right borders of both were within (line_margin \* height) of each other.  This accounted for left or right justification.

Add a case where one line's left and right border are both inside of another line's left and right border.  This handles a center justification of text.
