### PR TITLE
Added flag to pdf2txt to skip LTLayoutContainer.group_textboxes to speed up text generation on complex documents.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -270,6 +270,10 @@ when determining a text order. The value should be within the range of
 -1.0 (only horizontal position matters) to +1.0 (only vertical position matters).
 The default value is 0.5.
 <p>
+<dt> <code>-S</code> 
+<dd> Forces layout to skip grouping of textboxes. This may speed up the process for
+complex files.
+<p>
 <dt> <code>-C</code> 
 <dd> Suppress object caching. 
 This will reduce the memory consumption but also slows down the process.

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -39,7 +39,8 @@ class LAParams(object):
                  word_margin=0.1,
                  boxes_flow=0.5,
                  detect_vertical=False,
-                 all_texts=False):
+                 all_texts=False,
+                 group_textboxes=True ):
         self.line_overlap = line_overlap
         self.char_margin = char_margin
         self.line_margin = line_margin
@@ -47,11 +48,13 @@ class LAParams(object):
         self.boxes_flow = boxes_flow
         self.detect_vertical = detect_vertical
         self.all_texts = all_texts
+        self.group_textboxes = group_textboxes
         return
 
     def __repr__(self):
         return ('<LAParams: char_margin=%.1f, line_margin=%.1f, word_margin=%.1f all_texts=%r>' %
-                (self.char_margin, self.line_margin, self.word_margin, self.all_texts))
+                (self.char_margin, self.line_margin, self.word_margin, self.all_texts, 
+                 self.group_textboxes))
 
 
 ##  LTItem
@@ -598,6 +601,12 @@ class LTLayoutContainer(LTContainer):
     # group_textboxes: group textboxes hierarchically.
     def group_textboxes(self, laparams, boxes):
         assert boxes
+
+        if not self.group_textboxes:            
+            # plane = Plane(self.bbox)
+            # plane.extend(boxes)
+            # return list(plane)
+            return boxes
 
         def dist(obj1, obj2):
             """A distance function between two TextBoxes.

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -5,7 +5,7 @@ CMP=:
 ECHO=echo
 PYTHON=python2
 
-PDF2TXT=PYTHONPATH=.. time $(PYTHON) ../tools/pdf2txt.py -p1 -V
+PDF2TXT=PYTHONPATH=.. $(PYTHON) ../tools/pdf2txt.py -p1 -V
 
 FREE= \
 	simple1 \

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -5,7 +5,7 @@ CMP=:
 ECHO=echo
 PYTHON=python2
 
-PDF2TXT=PYTHONPATH=.. $(PYTHON) ../tools/pdf2txt.py -p1 -V
+PDF2TXT=PYTHONPATH=.. time $(PYTHON) ../tools/pdf2txt.py -p1 -V
 
 FREE= \
 	simple1 \
@@ -46,6 +46,11 @@ tests:
 		$(PDF2TXT) -t text -o $$i.txt $$i.pdf || eixt 1; \
 		$(CMP) $$i.txt $$i.txt.ref || exit 1; \
 	done
+	for i in $(TESTS); do \
+		$(ECHO) $$i; \
+		$(PDF2TXT) -t text -o $$i.txt2 -S $$i.pdf || eixt 1; \
+		$(CMP) $$i.txt2 $$i.txt.ref || exit 1; \
+	done
 
 crypts:
 	for i in $(CRYPTS); do \
@@ -61,7 +66,7 @@ test:
 
 clean:
 	-for i in $(TESTS); do \
-		$(RM) $$i.html $$i.xml $$i.txt; \
+		$(RM) $$i.html $$i.xml $$i.txt $$i.txt2; \
 	done
 	-for i in $(CRYPTS); do \
 		$(RM) $$i.1.xml $$i.2.xml; \

--- a/tools/pdf2txt.py
+++ b/tools/pdf2txt.py
@@ -17,7 +17,7 @@ def main(argv):
         print ('usage: %s [-d] [-p pagenos] [-m maxpages] [-P password] [-o output]'
                ' [-C] [-n] [-A] [-V] [-M char_margin] [-L line_margin] [-W word_margin]'
                ' [-F boxes_flow] [-Y layout_mode] [-O output_dir] [-R rotation] [-S]'
-               ' [-t text|html|xml|tag] [-c codec] [-s scale]'
+               ' [-t text|html|xml|tag] [-c codec] [-s scale] [-S]'
                ' file ...' % argv[0])
         return 100
     try:
@@ -58,6 +58,7 @@ def main(argv):
         elif k == '-L': laparams.line_margin = float(v)
         elif k == '-W': laparams.word_margin = float(v)
         elif k == '-F': laparams.boxes_flow = float(v)
+        elif k == '-S': laparams.group_textboxes = True
         elif k == '-Y': layoutmode = v
         elif k == '-O': imagewriter = ImageWriter(v)
         elif k == '-R': rotation = int(v)


### PR DESCRIPTION
When working on documents there were several papers that took longer
than 5 mintues to convert to text. In order to speed up text generation,
the work performed to generate a hierarcy by the LTLayoutContainer.group_textboxes
can be skiped. This can be enabled by a command line flag.

Added use of this flag to the tests.

Added description of -S flag to html pages.

Signed-off-by: Brian D. Caruso bdc34@cornell.edu
