### PR TITLE
exporting JBIG2 images

### DIFF
--- a/pdfminer/image.py
+++ b/pdfminer/image.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
+from cStringIO import StringIO
 import struct
 import os
 import os.path
 from io import BytesIO
+from .jbig2 import JBIG2StreamReader, JBIG2StreamWriter
 from .pdftypes import LITERALS_DCT_DECODE, LITERALS_JBIG2_DECODE
 from .pdfcolor import LITERAL_DEVICE_GRAY
 from .pdfcolor import LITERAL_DEVICE_RGB
@@ -103,7 +105,14 @@ class ImageWriter(object):
             else:
                 fp.write(raw_data)
         elif is_jbig2:
-            fp.write(stream.get_data())
+            input_stream = StringIO()
+            input_stream.write(stream.get_data())
+            input_stream.seek(0)
+            reader = JBIG2StreamReader(input_stream)
+            segments = reader.get_segments()
+
+            writer = JBIG2StreamWriter(fp)
+            writer.write_file(segments)
         elif image.bits == 1:
             bmp = BMPWriter(fp, 1, width, height)
             data = stream.get_data()

--- a/pdfminer/image.py
+++ b/pdfminer/image.py
@@ -91,6 +91,12 @@ class ImageWriter(object):
             ext = '.%d.%dx%d.img' % (image.bits, width, height)
         name = image.name+ext
         path = os.path.join(self.outdir, name)
+        img_index = 0
+        while os.path.exists(path):
+            name = '%s.%d%s' % (image.name, img_index, ext)
+            path = os.path.join(self.outdir, name)
+            img_index += 1
+
         fp = file(path, 'wb')
         if ext == '.jpg':
             raw_data = stream.get_rawdata()

--- a/pdfminer/jbig2.py
+++ b/pdfminer/jbig2.py
@@ -1,0 +1,140 @@
+import math
+import os
+from struct import pack, unpack, calcsize
+
+# segment header literals
+
+HEADER_FLAG_DEFERRED = 0b10000000
+HEADER_FLAG_PAGE_ASSOC_LONG = 0b01000000
+
+SEG_TYPE_MASK = 0b00111111
+
+REF_COUNT_SHORT_MASK = 0b11100000
+REF_COUNT_LONG_MASK = 0x1fffffff
+REF_COUNT_LONG = 7
+
+DATA_LEN_UNKNOWN = 0xffffffff
+
+# segment types
+
+SEG_TYPE_IMMEDIATE_GEN_REGION = 38
+
+def bit_set(bit_pos, value):
+    return bool((value >> bit_pos) & 1)
+
+def check_flag(flag, value):
+    return bool(flag & value)
+
+def masked_value(mask, value):
+    for bit_pos in range(0, 31):
+        if bit_set(bit_pos, mask):
+            return (value & mask) >> bit_pos
+
+    raise Exception("Invalid mask or value")
+
+class JBIG2StreamReader(object):
+    fields = [
+        (">L", "number"),
+        (">B", "flags"),
+        (">B", "retention_flags"),
+        (">B", "page_assoc"),
+        (">L", "data_length"),
+    ]
+
+    def __init__(self, stream):
+        self.stream = stream
+
+    def get_segments(self):
+        segments = []
+        while not self.is_eof():
+            segment = {}
+            for field_format, name in self.fields:
+                field_len = calcsize(field_format)
+                field = self.stream.read(field_len)
+                if len(field) < field_len:
+                    segment["_error"] = True
+                    break
+                value = unpack(field_format, field)
+                if len(value) == 1:
+                    [value] = value
+                parser = getattr(self, "parse_%s" % name, None)
+                if callable(parser):
+                    value = parser(segment, value, field)
+                segment[name] = value
+
+            if not segment.get("_error"):
+                segments.append(segment)
+        return segments
+
+    def is_eof(self):
+        if self.stream.read(1) == '':
+            return True
+        else:
+            self.stream.seek(-1, os.SEEK_CUR)
+            return False
+
+    def parse_flags(self, segment, flags, field):
+        return {
+            "deferred": check_flag(HEADER_FLAG_DEFERRED, flags),
+            "page_assoc_long": check_flag(HEADER_FLAG_PAGE_ASSOC_LONG, flags),
+            "type": masked_value(SEG_TYPE_MASK, flags)
+        }
+
+    def parse_retention_flags(self, segment, flags, field):
+        ref_count = masked_value(REF_COUNT_SHORT_MASK, flags)
+        retain_segments = []
+        ref_segments = []
+
+        if ref_count < REF_COUNT_LONG:
+            for bit_pos in range(5):
+                retain_segments.append(bit_set(bit_pos, flags))
+        else:
+            field += self.stream.read(3)
+            [ref_count] = unpack(">L", field)
+            ref_count = masked_value(REF_COUNT_LONG_MASK, ref_count)
+            ret_bytes_count = int(ceil((ref_count+1)/8))
+            for ret_byte_index in range(ret_bytes_count):
+                [ret_byte] = unpack(">B", self.stream.read(1))
+                for bit_pos in range(7):
+                    retain_segments.append(bit_set(bit_pos, ret_byte))
+
+        seg_num = segment["number"]
+        if seg_num <= 256:
+            ref_format = ">B"
+        elif seg_num <= 65536:
+            ref_format = ">I"
+        else:
+            ref_format = ">L"
+
+        ref_size = calcsize(ref_format)
+
+        for ref_index in range(ref_count):
+            ref = stream.read(ref_size)
+            [ref] = unpack(ref_format, ref)
+            ref_segments.append(ref)
+
+        return {
+            "ref_count": ref_count,
+            "retain_segments": retain_segments,
+            "ref_segments": ref_segments,
+        }
+
+    def parse_page_assoc(self, segment, page, field):
+        if segment["flags"]["page_assoc_long"]:
+            field += self.stream.read(3)
+            [page] = unpack(">L", field)
+        return page
+
+    def parse_data_length(self, segment, length, field):
+        if length:
+            if (segment["flags"]["type"] == SEG_TYPE_IMMEDIATE_GEN_REGION)\
+                and (length == DATA_LEN_UNKNOWN):
+
+                raise NotImplementedError(
+                    "Working with unknown segment length "
+                    "is not implemented yet"
+                )
+            else:
+                segment["data"] = self.stream.read(length)
+
+        return length

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -23,7 +23,7 @@ LITERALS_ASCIIHEX_DECODE = (LIT('ASCIIHexDecode'), LIT('AHx'))
 LITERALS_RUNLENGTH_DECODE = (LIT('RunLengthDecode'), LIT('RL'))
 LITERALS_CCITTFAX_DECODE = (LIT('CCITTFaxDecode'), LIT('CCF'))
 LITERALS_DCT_DECODE = (LIT('DCTDecode'), LIT('DCT'))
-
+LITERALS_JBIG2_DECODE = (LIT('JBIG2Decode'),)
 
 ##  PDF Objects
 ##
@@ -261,6 +261,8 @@ class PDFStream(PDFObject):
                 # This is probably a JPG stream - it does not need to be decoded twice.
                 # Just return the stream to the user.
                 pass
+            elif f in LITERALS_JBIG2_DECODE:
+                pass                
             elif f == LITERAL_CRYPT:
                 # not yet..
                 raise PDFNotImplementedError('/Crypt filter is unsupported')


### PR DESCRIPTION
I found out that pdfminer stumbles on PDF files with embedded images encoded by JBIG2 codec. This code allows to export that images to jbig2 files, which could be converted in another formats, for example, by jbig2dec tool.