### PR TITLE
Avoid timestamps in gzip-compressed file and compress more

### DIFF
--- a/tools/conv_cmap.py
+++ b/tools/conv_cmap.py
@@ -183,16 +183,22 @@ def main(argv):
         fname = '%s.pickle.gz' % enc
         path = os.path.join(outdir, fname)
         print ('writing: %r...' % path)
-        fp = gzip.open(path, 'wb')
-        converter.dump_cmap(fp, enc)
-        fp.close()
+        with open(path, 'wb') as fp:
+            # with statement support for GzipFile is available only from Python
+            # 2.7
+            fgz = gzip.GzipFile('', 'wb', 9, fp, 0.)
+            converter.dump_cmap(fgz, enc)
+            fgz.close()
 
     fname = 'to-unicode-%s.pickle.gz' % regname
     path = os.path.join(outdir, fname)
     print ('writing: %r...' % path)
-    fp = gzip.open(path, 'wb')
-    converter.dump_unicodemap(fp)
-    fp.close()
+    with open(path, 'wb') as fp:
+        # with statement support for GzipFile is available only from Python
+        # 2.7
+        fgz = gzip.GzipFile('', 'wb', 9, fp, 0.)
+        converter.dump_unicodemap(fgz)
+        fgz.close()
     return
 
 if __name__ == '__main__': sys.exit(main(sys.argv))


### PR DESCRIPTION
Without timestamps building it should be possible to reproduce, byte for
byte, every build of pdfminer.
Also, using compressionlevel=9 the size of data is considerably reduced.