### PR TITLE
PDFStream.get_filters: support multiple parameterless filters

### DIFF
--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -224,7 +224,7 @@ class PDFStream(PDFObject):
         if not isinstance(filters, list):
             filters = [filters]
         if not isinstance(params, list):
-            params = [params]
+            params = [params] * len(filters)
         return zip(filters, params)
 
     def decode(self):


### PR DESCRIPTION
Previously, if multiple filters were present but no DecodeParms, params
would be [{}] and the zip() would truncate the later filters. This tends to cause struct.unpack() errors when working with fonts which were packed with the combination /ASCII85Decode /FlateDecode. This may explain #96.

Instead, set params to be the same length as filters.
This still doesn't cover the case when params is non-empty, but still shorter than filters. Does that ever occur?