### PR TITLE
Handle name2unicode OverflowError exceptions like KeyError

### DIFF
--- a/pdfminer/encodingdb.py
+++ b/pdfminer/encodingdb.py
@@ -58,7 +58,7 @@ class EncodingDB(object):
                 elif isinstance(x, PSLiteral):
                     try:
                         cid2unicode[cid] = name2unicode(x.name)
-                    except KeyError:
+                    except (KeyError, OverflowError):
                         pass
                     cid += 1
         return cid2unicode

--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -111,7 +111,7 @@ class Type1FontHeaderParser(PSStackParser):
                 break
             try:
                 self._cid2unicode[cid] = name2unicode(name)
-            except KeyError:
+            except (KeyError, OverflowError):
                 pass
         return self._cid2unicode
 


### PR DESCRIPTION
A change to handle OverflowError exceptions that can be raised by
name2unicode.  The theory is that it is ok to ignore KeyError, so we
treat the OverflowError cases in the same way.  I am not clear on the
implication of this change, but believe that it amounts to throwing away
a character that we do not know how to properly encode.

I can't share an example PDF because they are proprietary to a client,
but I believe that the following from the PDF illustrates the problem.  This
pattern appears to be consistent across all of Sprint PDF statements.  The
PDF appears to be created by TargetStream Technologies tools.


<</Type /Encoding/Differences [0 /226215240241240240240240 64 /space 75 /period 91 /dollar 240 /zero /one /two /three /four 246 /six 249 /nine]>>endobj
106 0 obj
<</two 100 0 R/nine 104 0 R/one 99 0 R/three 101 0 R/dollar 97 0 R/four 102 0 R/zero 98 0 R/period 96 0 R/space 95 0 R/226215240241240240240240 94 0 R/six 103 0 R>>endobj


The 226215240241240240240240 value was passed as the name to the name2unicode function.  This is not in the glyphname2unicode map and so the regular expression matches on the entire string of digits.  An OverflowError is raised when attempting to convert that value into an int.

This change enables us to process PDFs that otherwise would result in an uncaught exception.  I believe that the downside of the change is that it quietly throws away a character that we don't know how to convert, but for our application, that is not a material problem, and matches the pattern
established for KeyError exceptions raised by the failure of the regular expression to match
any digits in the name.

Final comment is that the fix that we needed was the change to encodingdb.py, but for consistency sake I modified pdffont.py as well since it provides a consistent approach to the problem.
