### PR TITLE
Bugfix encodingdb: parsing hex instead of dec

### DIFF
--- a/pdfminer/encodingdb.py
+++ b/pdfminer/encodingdb.py
@@ -5,7 +5,7 @@ from .glyphlist import glyphname2unicode
 from .latin_enc import ENCODING
 
 
-STRIP_NAME = re.compile(r'[0-9]+')
+STRIP_NAME = re.compile(r'[0-9A-F]{4}$')
 
 
 ##  name2unicode
@@ -17,7 +17,7 @@ def name2unicode(name):
     m = STRIP_NAME.search(name)
     if not m:
         raise KeyError(name)
-    return unichr(int(m.group(0)))
+    return unichr(int(m.group(0),16))
 
 
 ##  EncodingDB


### PR DESCRIPTION
A pdf file produced text elements with wrongly encoded text.

Based on this specification file:

    github.com/adobe-type-tools/agl-aglfn/blob/master/glyphlist.txt#L44

The unicode scalar values use hexadecimal values. This was confirmed by
the sample pdf that included names like `uni004F`. This did not result
in an error because the regex simply matched digital strings.

The encodingdb.py file was modified such that it now matches the last
four characters as hexadecimal characters (and otherwise fails) and parses
them as a hexadecimal number.

Tests on the pdf seemed to resolve the issue.

Signed-off-by: Willem Van Onsem <vanonsem.willem@gmail.com>