### PR TITLE
fixes two issues found in malformed PDFs

### DIFF
--- a/pdfminer/pdfpage.py
+++ b/pdfminer/pdfpage.py
@@ -53,7 +53,7 @@ class PDFPage(object):
         self.attrs = dict_value(attrs)
         self.lastmod = resolve1(self.attrs.get('LastModified'))
         self.resources = resolve1(self.attrs.get('Resources', dict()))
-        self.mediabox = resolve1(self.attrs['MediaBox'])
+        self.mediabox = resolve1(self.attrs.get('MediaBox', (0,0,0,0)))
         if 'CropBox' in self.attrs:
             self.cropbox = resolve1(self.attrs['CropBox'])
         else:

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -270,6 +270,8 @@ class PDFStream(PDFObject):
             else:
                 raise PDFNotImplementedError('Unsupported filter: %r' % f)
             # apply predictors
+            if not params:
+                continue
             if 'Predictor' in params:
                 pred = int_value(params['Predictor'])
                 if pred == 1:


### PR DESCRIPTION
i use python to analyze malicious PDFs so i trip over stuff at times. this PR fixes two issues

- #56  - but specifically for the MediaBox attribute mentioned there
- #175 - applies the suggested patch (albeit a bit differently, same effect)

tested locally OK with malicious PDFs and benign PDFs