### PR TITLE
backslash escape dash, fix #167

### DIFF
--- a/tools/pdf2html.cgi
+++ b/tools/pdf2html.cgi
@@ -32,7 +32,7 @@ def q(x):
     return x.replace('&','&amp;').replace('>','&gt;').replace('<','&lt;').replace('"','&quot;')
 
 # encode parameters as a URL
-Q = re.compile(r'[^a-zA-Z0-9_.-=]')
+Q = re.compile(r'[^a-zA-Z0-9_.\-=]')
 def url(base, **kw):
     r = []
     for (k,v) in kw.iteritems():


### PR DESCRIPTION
with the backslash: 

```In [15]: Q = re.compile(r'[^a-zA-Z0-9_.\-=]', re.DEBUG)
in
  negate None
  range (97, 122)
  range (65, 90)
  range (48, 57)
  literal 95
  literal 46
  literal 45
  literal 61```

without it:

```
In [10]: Q = re.compile(r'[^a-zA-Z0-9_.-=]', re.DEBUG)
in
  negate None
  range (97, 122)
  range (65, 90)
  range (48, 57)
  literal 95
  range (46, 61)
```