### PR TITLE
Enabled PDFDevice in the with statement

### DIFF
--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -19,6 +19,12 @@ class PDFDevice(object):
     def __repr__(self):
         return '<PDFDevice>'
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
     def close(self):
         return
 


### PR DESCRIPTION
I enabled pdfminer.pdfdevice.PDFDevice and it's inherited classes in the with statement.

Example (Use pdfminer.converter.TextConverter which is pdfminer.pdfdevice.PDFDevice's inherited classes):

```py
import io

import pdfminer.converter
import pdfminer.layout
import pdfminer.pdfinterp
import pdfminer.pdfpage


def main():
    with io.StringIO() as return_text:
        resource_manager = pdfminer.pdfinterp.PDFResourceManager()

        with pdfminer.converter.TextConverter(resource_manager, return_text, laparams=pdfminer.layout.LAParams(detect_vertical=True)) as device:
            ...


if __name__ == '__main__':
    main()

```