### PR TITLE
Fixed bug with some files could not be extracted

### DIFF
--- a/pdfminer/pdfpage.py
+++ b/pdfminer/pdfpage.py
@@ -121,7 +121,7 @@ class PDFPage(object):
         # Create a PDF document object that stores the document structure.
         doc = PDFDocument(parser, password=password, caching=caching)
         # Check if the document allows text extraction. If not, abort.
-        if check_extractable and not doc.is_extractable:
+        if not check_extractable and not doc.is_extractable:
             raise PDFTextExtractionNotAllowed('Text extraction is not allowed: %r' % fp)
         # Process each page contained in the document.
         for (pageno, page) in enumerate(klass.create_pages(doc)):


### PR DESCRIPTION
Some files still can be extracted even though it raised exception (I've tried to comment the if completely, and it has extracted just fine).

Here's the file I've done testing with: https://drive.google.com/file/d/1DerQHjbuxrCI3RkivBwH5WJef0qYP9-B/view?usp=sharing