### PR TITLE
Bugfix in Algorithm 3.2

### DIFF
--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -351,7 +351,7 @@ class PDFStandardSecurityHandler(object):
         password = (password + self.PASSWORD_PADDING)[:32]  # 1
         hash = md5.md5(password)  # 2
         hash.update(self.o)  # 3
-        hash.update(struct.pack('<l', self.p))  # 4
+        hash.update(struct.pack('<L', self.p))  # 4
         hash.update(self.docid[0])  # 5
         if self.r >= 4:
             if not self.encrypt_metadata:


### PR DESCRIPTION
In accordance with PDF Reference (third edition, version 1.4):
4. Treat the value of the P entry as an `unsigned` 4-byte integer and pass these bytes to the MD5 hash function, low-order byte first.