### PR TITLE
Fixed issue when a compressed font is too big for the default sized zlib buffer

### DIFF
--- a/pdfminer/__init__.py
+++ b/pdfminer/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-__version__ = '20140328'
+__version__ = '20190215'
 
 if __name__ == '__main__':
     print (__version__)

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -245,7 +245,7 @@ class PDFStream(PDFObject):
             if f in LITERALS_FLATE_DECODE:
                 # will get errors if the document is encrypted.
                 try:
-                    data = zlib.decompress(data)
+                    data = zlib.decompressobj().decompress(data)
                 except zlib.error as e:
                     if STRICT:
                         raise PDFException('Invalid zlib bytes: %r, %r' % (e, data))


### PR DESCRIPTION
There are PDF files where an embedded font is so large that zlib runs out of default-sized buffer space when decompressing. The zlib module does have a way to not worry about the buffer size (and so the size of the font). This patch fixes the decompression so that it doesn't matter the amount of font data.