### PR TITLE
Fix struct unpack buffer error issue.

### DIFF
--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -124,7 +124,8 @@ class IdentityCMap(CMapBase):
     def decode(self, code):
         n = len(code)//2
         if n:
-            return struct.unpack('>%dH' % n, code)
+            # return struct.unpack('>%dH' % n, code)
+            return struct.unpack_from('=%dH' % n, code)
         else:
             return ()
 


### PR DESCRIPTION
I got a problem for parsing huge document contents when I used below as-is method.
so I changed method unpack to unpack_from and parameters, it works well for me.
(I'm not sure whether it is really fixed or not but after modifying method, parsing well.)

Error message)
struct error: unpack requires a buffer of 56 bytes
---------------------
(As-Is)
return struct.unpack('>%dH' % n, code)
(To-Be)
return struct.unpack_from('=%dH' % n, code)