### PR TITLE
Reverse the Python version requirement note in How to Install.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -103,8 +103,8 @@ http://groups.google.com/group/pdfminer-users/
 
 <h2><a name="install">How to Install</a></h2>
 <ol>
-<li> Install <a href="http://www.python.org/download/">Python</a> 2.6 or newer.
-     (<font color=red><strong>Python 3 is not supported.</strong></font>)
+<li> Install <a href="http://www.python.org/download/">Python</a> 3.6 or newer.
+     (<font color=red><strong>Python 2 is not supported.</strong></font>)
 <li> Download the <a href="#source">PDFMiner source</a>.
 <li> Unpack it.
 <li> Run <code>setup.py</code> to install:<br>


### PR DESCRIPTION
While I guess a lot of the docs are out of date by now, it at least makes sense to avoid the conflicting information from README.md.