### PR TITLE
update fmttype as 6

### DIFF
--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -425,7 +425,7 @@ class TrueTypeFont:
                         if gid:
                             gid += delta
                         char2gid[first+c] = gid
-            elif fmttype == 4:
+            elif fmttype == 6 or fmttype == 4:
                 (segcount, _1, _2, _3) = struct.unpack('>HHHH', fp.read(8))
                 segcount //= 2
                 ecs = struct.unpack('>%dH' % segcount, fp.read(2*segcount))


### PR DESCRIPTION
without fmttype as 6, pdfminer was unable to read the file. Threw an exception as assert False, str(('Unhandled', 6))

Please accept this, to avoid any issues on formats of such values